### PR TITLE
HWDEV-1479 modification patch of led_controller warnings

### DIFF
--- a/lexxpluss_apps/src/led_controller.hpp
+++ b/lexxpluss_apps/src/led_controller.hpp
@@ -41,13 +41,7 @@ struct msg {
     msg() : pattern(NONE), interrupt_ms(0) {}
     msg(uint32_t pattern, uint32_t interrupt_ms) :
         pattern(pattern), interrupt_ms(interrupt_ms) {}
-    msg(can_format frame) {
-        pattern = frame.pattern;
-        cpm = frame.count_per_minutes;
-        rgb[0] = frame.rgb[0];
-        rgb[1] = frame.rgb[1];
-        rgb[2] = frame.rgb[2];
-    }
+    msg(can_format frame) : pattern(frame.pattern), cpm(frame.count_per_minutes), rgb{frame.rgb[0],frame.rgb[1],frame.rgb[2]} {}
 
     msg(const char *str) {
         if      (strcmp(str, "emergency_stop")  == 0) pattern = EMERGENCY_STOP;
@@ -107,8 +101,9 @@ struct msg {
              : (c >= 'A' && c <= 'F') ? c - 'A' + 10
                                       : -1;
     }
+    uint8_t pattern{NONE};
     uint32_t interrupt_ms{0}, cpm{0};
-    uint8_t pattern{NONE}, rgb[3]{0, 0, 0};
+    uint8_t rgb[3]{0, 0, 0};
     static constexpr uint8_t NONE{0};
     static constexpr uint8_t EMERGENCY_STOP{1};
     static constexpr uint8_t AMR_MODE{2};


### PR DESCRIPTION
HWDEV-1479

LEDのコードで出してしまっていた　warningの修正になります。

# warningの内容
```
[23/181] Building CXX object CMakeFiles/app.dir/src/main.cpp.obj
In file included from /workdir/LexxHard-SensorControlBoard-Firmware/lexxpluss_apps/src/main.cpp:34:
/workdir/LexxHard-SensorControlBoard-Firmware/lexxpluss_apps/src/led_controller.hpp: In constructor 'lexxhard::led_controller::msg::msg()':
/workdir/LexxHard-SensorControlBoard-Firmware/lexxpluss_apps/src/led_controller.hpp:112:13: warning: 'lexxhard::led_controller::msg::pattern' will be initialized after [-Wreorder]
  112 |     uint8_t pattern{NONE}, rgb[3]{0, 0, 0};
      |             ^~~~~~~
/workdir/LexxHard-SensorControlBoard-Firmware/lexxpluss_apps/src/led_controller.hpp:111:14: warning:   'uint32_t lexxhard::led_controller::msg::interrupt_ms' [-Wreorder]
  111 |     uint32_t interrupt_ms{0}, cpm{0};
      |              ^~~~~~~~~~~~
In file included from /workdir/LexxHard-SensorControlBoard-Firmware/lexxpluss_apps/src/main.cpp:34:
/workdir/LexxHard-SensorControlBoard-Firmware/lexxpluss_apps/src/led_controller.hpp:41:5: warning:   when initialized here [-Wreorder]
   41 |     msg() : pattern(NONE), interrupt_ms(0) {}
      |     ^~~
In file included from /workdir/LexxHard-SensorControlBoard-Firmware/lexxpluss_apps/src/main.cpp:34:
/workdir/LexxHard-SensorControlBoard-Firmware/lexxpluss_apps/src/led_controller.hpp: In constructor 'lexxhard::led_controller::msg::msg(uint32_t, uint32_t)':
/workdir/LexxHard-SensorControlBoard-Firmware/lexxpluss_apps/src/led_controller.hpp:112:13: warning: 'lexxhard::led_controller::msg::pattern' will be initialized after [-Wreorder]
  112 |     uint8_t pattern{NONE}, rgb[3]{0, 0, 0};
      |             ^~~~~~~
/workdir/LexxHard-SensorControlBoard-Firmware/lexxpluss_apps/src/led_controller.hpp:111:14: warning:   'uint32_t lexxhard::led_controller::msg::interrupt_ms' [-Wreorder]
  111 |     uint32_t interrupt_ms{0}, cpm{0};
      |              ^~~~~~~~~~~~
In file included from /workdir/LexxHard-SensorControlBoard-Firmware/lexxpluss_apps/src/main.cpp:34:
/workdir/LexxHard-SensorControlBoard-Firmware/lexxpluss_apps/src/led_controller.hpp:42:5: warning:   when initialized here [-Wreorder]
   42 |     msg(uint32_t pattern, uint32_t interrupt_ms) :
      |     ^~~
In file included from /workdir/LexxHard-SensorControlBoard-Firmware/lexxpluss_apps/src/main.cpp:34:
/workdir/LexxHard-SensorControlBoard-Firmware/lexxpluss_apps/src/led_controller.hpp: In constructor 'lexxhard::led_controller::msg::msg(lexxhard::led_controller::can_format)':
/workdir/LexxHard-SensorControlBoard-Firmware/lexxpluss_apps/src/led_controller.hpp:112:13: warning: 'lexxhard::led_controller::msg::pattern' will be initialized after [-Wreorder]
  112 |     uint8_t pattern{NONE}, rgb[3]{0, 0, 0};
      |             ^~~~~~~
/workdir/LexxHard-SensorControlBoard-Firmware/lexxpluss_apps/src/led_controller.hpp:111:31: warning:   'uint32_t lexxhard::led_controller::msg::cpm' [-Wreorder]
  111 |     uint32_t interrupt_ms{0}, cpm{0};
      |                               ^~~
```

# ChatGPTの回答
```
これらの警告は、メンバ初期化リストでのメンバの初期化の順序が宣言された順序と異なることを示しています。具体的には、C++コンパイラがメンバの初期化リスト内で指定された順序と、クラス/構造体の定義内でメンバが宣言された順序が一致しない場合に発生します。

例えば、次のような警告が表示されています：

rust
Copy code
warning: 'lexxhard::led_controller::msg::pattern' will be initialized after [-Wreorder]
これは、lexxhard::led_controller::msg の初期化リストで pattern メンバが interrupt_ms メンバよりも先に初期化されることを示しています。しかし、lexxhard::led_controller::msg の定義では、interrupt_ms メンバが pattern メンバよりも先に宣言されています。

この警告は、コードの実行には影響しませんが、メンバの初期化の順序が意図しない場合にバグの原因となる可能性があるため、重要です。初期化リストでメンバの初期化順序を修正することで、警告を解消することができます。
```

原因は以下の箇所で、
```
    uint32_t interrupt_ms{0}, cpm{0};
    uint8_t pattern{NONE}, rgb[3]{0, 0, 0};
```
ここは私が以前以下から書き換えたものです。
```
    uint32_t pattern{NONE}, interrupt_ms{0}, cpm{0};
    uint8_t rgb[3]{0, 0, 0};
```
このときにpatternはuint32_tでしたが、uint8_tのほうが良いというアドバイスを受け書き換えました。しかしその際にここが構造体の定義であることを忘れ。上記のように書き換えました。
よって構造体内のメンバの定義順が変わってしまい、他の初期化の箇所における順番の矛盾に関するワーニングが出ていました。

以上。

上記とは別に、私が書いたコンストラクタが他のコンストラクタ初期化子による書き方と異なっていたので、そこも一緒に変えました。これは必須の変更ではないし主題とは異なるのでお行儀が悪いですが。。。

これらの変更によりワーニングがでなくなったことを確認済みです。
