### PR TITLE
HWDEV-1250 lift actuator center

### DIFF
--- a/lexxpluss_apps/src/actuator_controller.cpp
+++ b/lexxpluss_apps/src/actuator_controller.cpp
@@ -389,7 +389,7 @@ public:
     // }
 private:
     int32_t calc_current(int32_t adc_voltage_mv) const {
-        static constexpr float AMP_GAIN{20.0f}, VOLTAGE_DIVIDER{3.0f}, SHUNT_REGISTER{0.1f};
+        static constexpr float AMP_GAIN{50.0f}, VOLTAGE_DIVIDER{1.0f}, SHUNT_REGISTER{0.01f};
         float current_a{adc_voltage_mv * 1e-3f / AMP_GAIN * VOLTAGE_DIVIDER / SHUNT_REGISTER};
         return static_cast<int32_t>(current_a * 1e+3f);
     }

--- a/lexxpluss_apps/src/actuator_controller.cpp
+++ b/lexxpluss_apps/src/actuator_controller.cpp
@@ -89,7 +89,7 @@ struct msg_pwmtrampoline {
 K_MSGQ_DEFINE(msgq_pwmtrampoline, sizeof (msg_pwmtrampoline), 8, 4);
 
 enum class POS {
-    LEFT, CENTER, RIGHT
+    CENTER, LEFT, RIGHT
 };
 
 // This is the class of the HAL encoder so we will use only for center actuator probably
@@ -146,13 +146,13 @@ public:
     int init(POS pos) {
         int result{0};
         switch (pos) {
-        case POS::LEFT:
-            // result = enc.init(TIM3);
-            // mm_per_pulse = 50.0f / 1054.0f;
-            break;
         case POS::CENTER:
             result = enc.init(TIM4);
             mm_per_pulse = 50.0f / 1054.0f;
+            break;
+        case POS::LEFT:
+            // result = enc.init(TIM3);
+            // mm_per_pulse = 50.0f / 1054.0f;
             break;
         case POS::RIGHT:
             // result = enc.init(TIM1);
@@ -207,17 +207,17 @@ class pwm_driver {
 public:
     int init(POS pos) {
         switch (pos) {
-        case POS::LEFT:
-            // dev[0] = device_get_binding("PWM_8");
-            // dev[1] = dev[0];
-            // pin[0] = 1;
-            // pin[1] = 2;
-            break;
         case POS::CENTER:
             dev[0] = device_get_binding("PWM_5");
             dev[1] = dev[0];
             pin[0] = 1;
             pin[1] = 2;
+            break;
+        case POS::LEFT:
+            // dev[0] = device_get_binding("PWM_8");
+            // dev[1] = dev[0];
+            // pin[0] = 1;
+            // pin[1] = 2;
             break;
         case POS::RIGHT:
             // dev[0] = device_get_binding("PWM_2");
@@ -323,16 +323,16 @@ public:
             return -1;
         cnt.init(pos);
         switch (pos) {
-        case POS::LEFT:
-            current_adc = adc_reader::ACTUATOR_0;
-            fail_checker.init("GPIOG", 8);
-            break;
         case POS::CENTER:
-            current_adc = adc_reader::ACTUATOR_1;
+            current_adc = adc_reader::ACTUATOR_C;
             fail_checker.init("GPIOD", 10);
             break;
+        case POS::LEFT:
+            current_adc = adc_reader::ACTUATOR_L;
+            fail_checker.init("GPIOG", 8);
+            break;
         case POS::RIGHT:
-            current_adc = adc_reader::ACTUATOR_2;
+            current_adc = adc_reader::ACTUATOR_R;
             fail_checker.init("GPIOE", 10);
             break;
         }
@@ -419,8 +419,8 @@ public:
     int init() {
         k_msgq_init(&msgq, msgq_buffer, sizeof (msg), 8);
         k_msgq_init(&msgq_control, msgq_control_buffer, sizeof (msg_control), 8);
-        if (act[0].init(POS::LEFT) != 0 ||
-            act[1].init(POS::CENTER) != 0 ||
+        if (act[0].init(POS::CENTER) != 0 ||
+            act[1].init(POS::LEFT) != 0 ||
             act[2].init(POS::RIGHT) != 0)
             return -1;
         return 0;
@@ -543,6 +543,7 @@ public:
     void set_current_monitor() const {
     }
     void info(const shell *shell) const {
+        shell_print(shell, "[notice] The order changed from Left-Center-Right(prev) -> Center-Left-Right(NOW)");
         for (uint32_t i{0}; i < ACTUATOR_NUM; ++i) {
             auto [pulse, current, fail, direction, duty]{act[i].get_info()};
             shell_print(shell,
@@ -609,6 +610,7 @@ private:
 
 int cmd_duty(const shell *shell, size_t argc, char **argv)
 {
+    shell_print(shell, "[notice] The order changed from Left-Center-Right(prev) -> Center-Left-Right(NOW)");
     if (argc != 3 && argc != 5 && argc != 7) {
         shell_error(shell, "Usage: %s %s <direction> <power> ...\n", argv[-1], argv[0]);
         return 1;
@@ -624,6 +626,7 @@ int cmd_duty(const shell *shell, size_t argc, char **argv)
 
 int cmd_init(const shell *shell, size_t argc, char **argv)
 {
+    shell_print(shell, "[notice] The order changed from Left-Center-Right(prev) -> Center-Left-Right(NOW)");
     if (impl.init_location() != 0)
         shell_print(shell, "init error.");
     return 0;
@@ -631,6 +634,7 @@ int cmd_init(const shell *shell, size_t argc, char **argv)
 
 int locate(const shell *shell, size_t argc, char **argv)
 {
+    shell_print(shell, "[notice] The order changed from Left-Center-Right(prev) -> Center-Left-Right(NOW)");
     uint8_t location[ACTUATOR_NUM]{0, 0, 0}, power[ACTUATOR_NUM]{0, 0, 0}, detail[ACTUATOR_NUM]{0, 0, 0};
     if (argc != 3 && argc != 5 && argc != 7) {
         shell_error(shell, "Usage: %s %s <location> <power> ...\n", argv[-1], argv[0]);

--- a/lexxpluss_apps/src/actuator_controller.cpp
+++ b/lexxpluss_apps/src/actuator_controller.cpp
@@ -58,7 +58,7 @@ extern "C" void HAL_TIM_Encoder_MspInit(TIM_HandleTypeDef *htim_encoder)
     //     GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
     //     GPIO_InitStruct.Alternate = GPIO_AF2_TIM3;
     //     HAL_GPIO_Init(GPIOC, &GPIO_InitStruct);
-    //} else 
+    // } else 
     if(htim_encoder->Instance == TIM4) {
         __HAL_RCC_TIM4_CLK_ENABLE();
         __HAL_RCC_GPIOD_CLK_ENABLE();
@@ -78,8 +78,6 @@ LOG_MODULE_REGISTER(actuator);
 char __aligned(4) msgq_buffer[8 * sizeof (msg)];
 char __aligned(4) msgq_control_buffer[8 * sizeof (msg_control)];
 
-// char __aligned(4) msgq_can_actuator_control_buffer[8 * sizeof (ms)];
-
 static constexpr uint32_t ACTUATOR_NUM{3};
 
 struct msg_pwmtrampoline {
@@ -94,7 +92,7 @@ enum class POS {
     LEFT, CENTER, RIGHT
 };
 
-//This is the class of the HAL encoder so we will use only for center actuator probably
+// This is the class of the HAL encoder so we will use only for center actuator probably
 class encoder {
 public:
     int init(TIM_TypeDef *tim) {
@@ -139,7 +137,7 @@ private:
     TIM_HandleTypeDef timh;
 };
 
-//This class for encoder count, this calls encoder class
+// This class for encoder count, this calls encoder class
 
 // May be we can add software-encoder features here?
 
@@ -149,17 +147,17 @@ public:
         int result{0};
         switch (pos) {
         case POS::LEFT:
-        //     result = enc.init(TIM3);
-        //     mm_per_pulse = 50.0f / 1054.0f;
-             break;
+            // result = enc.init(TIM3);
+            // mm_per_pulse = 50.0f / 1054.0f;
+            break;
         case POS::CENTER:
             result = enc.init(TIM4);
             mm_per_pulse = 50.0f / 1054.0f;
             break;
         case POS::RIGHT:
-        //     result = enc.init(TIM1);
-        //     mm_per_pulse = 50.0f / 1054.0f;
-             break;
+            // result = enc.init(TIM1);
+            // mm_per_pulse = 50.0f / 1054.0f;
+            break;
         }
         reset_pulse();
         return result;
@@ -204,17 +202,17 @@ private:
     int32_t velocity{0}, pulse_value{0}, prev_pulse_value{0};
 };
 
-//This class for control 2 GPIOs as PWM
+// This class for control 2 GPIOs as PWM
 class pwm_driver {
 public:
     int init(POS pos) {
         switch (pos) {
         case POS::LEFT:
-        //     dev[0] = device_get_binding("PWM_8");
-        //     dev[1] = dev[0];
-        //     pin[0] = 1;
-        //     pin[1] = 2;
-             break;
+            // dev[0] = device_get_binding("PWM_8");
+            // dev[1] = dev[0];
+            // pin[0] = 1;
+            // pin[1] = 2;
+            break;
         case POS::CENTER:
             dev[0] = device_get_binding("PWM_5");
             dev[1] = dev[0];
@@ -222,11 +220,11 @@ public:
             pin[1] = 2;
             break;
         case POS::RIGHT:
-        //     dev[0] = device_get_binding("PWM_2");
-        //     dev[1] = dev[0];
-        //     pin[0] = 3;
-        //     pin[1] = 4;
-             break;
+            // dev[0] = device_get_binding("PWM_2");
+            // dev[1] = dev[0];
+            // pin[0] = 3;
+            // pin[1] = 4;
+            break;
         }
         if (!device_is_ready(dev[0]) || !device_is_ready(dev[1]))
             return -1;
@@ -257,7 +255,7 @@ private:
     static constexpr uint32_t CONTROL_PERIOD_NS{1000000000ULL / CONTROL_HZ};
 };
 
-//This calls counter, 
+// This calls counter
 class position_control {
 public:
     position_control(counter &cnt) : cnt(cnt) {}
@@ -317,7 +315,7 @@ private:
     static constexpr float POS_P{1.0f}, VEL_P{0.0f}, VEL_I{0.13f};
 };
 
-//This calls all
+// This calls all
 class actuator {
 public:
     int init(POS pos) {
@@ -429,7 +427,7 @@ public:
     }
 
     void run() {
-        //Enable Pin, Reset Functions
+        // Enable Pin, Reset Functions
         const device *dev_enable{device_get_binding("GPIOJ")};
         if (device_is_ready(dev_enable))
             gpio_pin_configure(dev_enable, 0, GPIO_OUTPUT_LOW | GPIO_ACTIVE_HIGH);
@@ -460,7 +458,7 @@ public:
         };
         reset_actuator();
 
-        //Heartbeat LED 5
+        // Heartbeat LED 5
         // const device *gpiog{device_get_binding("GPIOG")};
         // if (device_is_ready(gpiog))
         //     gpio_pin_configure(gpiog, 5, GPIO_OUTPUT_LOW | GPIO_ACTIVE_HIGH);

--- a/lexxpluss_apps/src/actuator_controller.cpp
+++ b/lexxpluss_apps/src/actuator_controller.cpp
@@ -140,10 +140,10 @@ public:
     int init(POS pos) {
         int result{0};
         switch (pos) {
-        case POS::LEFT:
-            result = enc.init(TIM3);
-            mm_per_pulse = 50.0f / 1054.0f;
-            break;
+        // case POS::LEFT:
+        //     result = enc.init(TIM3);
+        //     mm_per_pulse = 50.0f / 1054.0f;
+        //     break;
         case POS::CENTER:
             result = enc.init(TIM4);
             mm_per_pulse = 50.0f / 1054.0f;

--- a/lexxpluss_apps/src/actuator_controller.cpp
+++ b/lexxpluss_apps/src/actuator_controller.cpp
@@ -34,7 +34,6 @@
 #include <cstdlib>
 #include <tuple>
 #include "actuator_controller.hpp"
-#include "actuator_controller.cpp" // can delete
 #include "adc_reader.hpp"
 #include "can_controller.hpp"
 
@@ -149,18 +148,18 @@ public:
     int init(POS pos) {
         int result{0};
         switch (pos) {
-        // case POS::LEFT:
+        case POS::LEFT:
         //     result = enc.init(TIM3);
         //     mm_per_pulse = 50.0f / 1054.0f;
-        //     break;
+             break;
         case POS::CENTER:
             result = enc.init(TIM4);
             mm_per_pulse = 50.0f / 1054.0f;
             break;
-        // case POS::RIGHT:
+        case POS::RIGHT:
         //     result = enc.init(TIM1);
         //     mm_per_pulse = 50.0f / 1054.0f;
-        //     break;
+             break;
         }
         reset_pulse();
         return result;
@@ -210,24 +209,24 @@ class pwm_driver {
 public:
     int init(POS pos) {
         switch (pos) {
-        // case POS::LEFT:
+        case POS::LEFT:
         //     dev[0] = device_get_binding("PWM_8");
         //     dev[1] = dev[0];
         //     pin[0] = 1;
         //     pin[1] = 2;
-        //     break;
+             break;
         case POS::CENTER:
             dev[0] = device_get_binding("PWM_5");
             dev[1] = dev[0];
             pin[0] = 1;
             pin[1] = 2;
             break;
-        // case POS::RIGHT:
+        case POS::RIGHT:
         //     dev[0] = device_get_binding("PWM_2");
         //     dev[1] = dev[0];
         //     pin[0] = 3;
         //     pin[1] = 4;
-        //     break;
+             break;
         }
         if (!device_is_ready(dev[0]) || !device_is_ready(dev[1]))
             return -1;
@@ -468,15 +467,15 @@ public:
         // int heartbeat_led{1};
         // for (uint32_t i{0}; i < ACTUATOR_NUM; ++i)
         //     act[i].reset();
-        // uint32_t prev_cycle{k_cycle_get_32()};
+        uint32_t prev_cycle{k_cycle_get_32()};
 
         while (true) {
             for (uint32_t i{0}; i < ACTUATOR_NUM; ++i)
                 act[i].poll();
             bool is_emergency{can_controller::is_emergency()};  // -> board controller
-            msg_control ros2actuator;
-            if (k_msgq_get(&msgq_control, &ros2actuator, K_NO_WAIT) == 0 && !is_emergency)
-                handle_control(ros2actuator);
+            msg_control can2actuator;
+            if (k_msgq_get(&msgq_control, &can2actuator, K_NO_WAIT) == 0 && !is_emergency)
+                handle_control(can2actuator);
             msg_pwmtrampoline pwmtrampoline;
             if (k_msgq_get(&msgq_pwmtrampoline, &pwmtrampoline, K_NO_WAIT) == 0 && !is_emergency)
                 handle_pwmtrampoline(pwmtrampoline);
@@ -490,7 +489,7 @@ public:
                 for (uint32_t i{0}; i < ACTUATOR_NUM; ++i) {
                     int8_t direction;
                     uint8_t duty;
-                    std::tie(actuator2ros.encoder_count[i],
+                    std::tie(actuator2can.encoder_count[i],
                              actuator2can.current[i],
                              actuator2can.fail[i],
                              direction,

--- a/lexxpluss_apps/src/actuator_controller.hpp
+++ b/lexxpluss_apps/src/actuator_controller.hpp
@@ -30,18 +30,18 @@
 namespace lexxhard::actuator_controller {
 
 struct can_format_control {
-    int8_t direction[3]; // Left / Center / Right, -1:down, 0:stop, 1:up
-    uint8_t power_duty[3]; // Left / Center / Right, 0-100 duty[%]
+    int8_t direction[3]; // Center / Left / Right, -1:down, 0:stop, 1:up
+    uint8_t power_duty[3]; // Center / Left / Right, 0-100 duty[%]
 } __attribute__((aligned(4)));
 
 struct can_format_encoder {
     can_format_encoder(int16_t enc0,int16_t enc1,int16_t enc2) : encoder_count{enc0, enc1, enc2} {} 
-    int16_t encoder_count[3]; // Left / Center / Right
+    int16_t encoder_count[3]; // Center / Left / Right
 } __attribute__((aligned(4)));
 
 struct can_format_current {
     can_format_current(int16_t cur0,int16_t cur1,int16_t cur2, int16_t con) : current_mv{cur0, cur1, cur2}, connection_mv(con) {} 
-    int16_t current_mv[3]; // Left / Center / Right
+    int16_t current_mv[3]; // Center / Left / Right
     int16_t connection_mv;
 } __attribute__((aligned(4)));
 

--- a/lexxpluss_apps/src/actuator_controller.hpp
+++ b/lexxpluss_apps/src/actuator_controller.hpp
@@ -29,7 +29,41 @@
 
 namespace lexxhard::actuator_controller {
 
+struct can_format_control {
+    int8_t direction[3]; // Left / Center / Right, -1:down, 0:stop, 1:up
+    uint8_t power_duty[3]; // Left / Center / Right, 0-100 duty[%]
+} __attribute__((aligned(4)));
+
+struct can_format_encoder {
+    can_format_encoder(int16_t enc0,int16_t enc1,int16_t enc2) : encoder_count{enc0, enc1, enc2} {} 
+    int16_t encoder_count[3]; // Left / Center / Right
+} __attribute__((aligned(4)));
+
+struct can_format_current {
+    can_format_current(int16_t cur0,int16_t cur1,int16_t cur2, int16_t con) : current_mv{cur0, cur1, cur2}, connection_mv(con) {} 
+    int16_t current_mv[3]; // Left / Center / Right
+    int16_t connection_mv;
+} __attribute__((aligned(4)));
+
 struct msg_control {
+
+    msg_control(can_format_control frame)
+    : actuators
+    {
+        {
+            frame.direction[0],
+            frame.power_duty[0]
+        },
+        {
+            frame.direction[1],
+            frame.power_duty[1]
+        },
+        {
+            frame.direction[2],
+            frame.power_duty[2]
+        }
+    } {}
+
     struct {
         int8_t direction;
         uint8_t power;

--- a/lexxpluss_apps/src/actuator_controller.hpp
+++ b/lexxpluss_apps/src/actuator_controller.hpp
@@ -85,6 +85,8 @@ int to_location(const uint8_t (&location)[3], const uint8_t (&power)[3], uint8_t
 extern k_thread thread;
 extern k_msgq msgq, msgq_control;
 
+// k_msgq msgq_can_actuator_control;
+
 }
 
 // vim: set expandtab shiftwidth=4:

--- a/lexxpluss_apps/src/actuator_controller.hpp
+++ b/lexxpluss_apps/src/actuator_controller.hpp
@@ -47,6 +47,7 @@ struct can_format_current {
 
 struct msg_control {
 
+    msg_control(){}
     msg_control(can_format_control frame)
     : actuators
     {
@@ -84,8 +85,6 @@ int init_location();
 int to_location(const uint8_t (&location)[3], const uint8_t (&power)[3], uint8_t (&detail)[3]);
 extern k_thread thread;
 extern k_msgq msgq, msgq_control;
-
-// k_msgq msgq_can_actuator_control;
 
 }
 

--- a/lexxpluss_apps/src/adc_reader.hpp
+++ b/lexxpluss_apps/src/adc_reader.hpp
@@ -38,9 +38,9 @@ enum {
     DOWNWARD_L = 0,
     DOWNWARD_R,
     TROLLEY,
-    ACTUATOR_0,
-    ACTUATOR_1,
-    ACTUATOR_2,
+    ACTUATOR_L,
+    ACTUATOR_C,
+    ACTUATOR_R,
     NUM_CHANNELS
 };
 

--- a/lexxpluss_apps/src/main.cpp
+++ b/lexxpluss_apps/src/main.cpp
@@ -87,7 +87,6 @@ void main()
     lexxhard::misc_controller::init();
     lexxhard::pgv_controller::init();
     lexxhard::rosserial::init();
-    lexxhard::rosserial_service::init();
     lexxhard::runaway_detector::init();
     lexxhard::tof_controller::init();
     lexxhard::uss_controller::init();
@@ -104,7 +103,6 @@ void main()
     RUN(uss_controller, 2);
     RUN(runaway_detector, 4);
     RUN(rosserial, 5); // The rosserial thread will be started last.
-    RUN(rosserial_service, 6); // The rosserial thread will be started last.
     const device *gpiog{device_get_binding("GPIOG")};
     if (gpiog != nullptr)
         gpio_pin_configure(gpiog, 7, GPIO_OUTPUT_LOW | GPIO_ACTIVE_HIGH);

--- a/lexxpluss_apps/src/rosserial.cpp
+++ b/lexxpluss_apps/src/rosserial.cpp
@@ -24,7 +24,6 @@
  */
 
 #include "rosserial_hardware_zephyr.hpp"
-#include "rosserial_actuator.hpp"
 #include "rosserial_bmu.hpp"
 #include "rosserial_board.hpp"
 #include "rosserial_dfu.hpp"

--- a/lexxpluss_apps/src/rosserial.cpp
+++ b/lexxpluss_apps/src/rosserial.cpp
@@ -41,7 +41,6 @@ public:
     int init() {
         nh.getHardware()->set_baudrate(921600);
         nh.initNode(const_cast<char*>("UART_6"));
-        actuator.init(nh);
         bmu.init(nh);
         board.init(nh);
         dfu.init(nh);
@@ -54,7 +53,6 @@ public:
     void run() {
         while (true) {
             nh.spinOnce();
-            actuator.poll();
             bmu.poll();
             board.poll();
             dfu.poll();
@@ -67,7 +65,6 @@ public:
     }
 private:
     ros::NodeHandle nh;
-    ros_actuator actuator;
     ros_bmu bmu;
     ros_board board;
     ros_dfu dfu;

--- a/lexxpluss_apps/src/rosserial_actuator.hpp
+++ b/lexxpluss_apps/src/rosserial_actuator.hpp
@@ -77,7 +77,7 @@ public:
                 .id_type = CAN_STANDARD_IDENTIFIER,
                 .dlc = CAN_DATALENGTH_ACTUATOR_ENCODER
             };
-            actuator_controller::can_format_encoder tmp_enc = actuator_controller::can_format_encoder(message.encoder_count[1], message.encoder_count[0], message.encoder_count[2]);
+            actuator_controller::can_format_encoder tmp_enc = actuator_controller::can_format_encoder(message.encoder_count[0], message.encoder_count[1], message.encoder_count[2]);
             memcpy(can_frame_actuator_encoder.data, &tmp_enc, CAN_DATALENGTH_ACTUATOR_ENCODER);
 
             zcan_frame can_frame_actuator_current{
@@ -86,7 +86,7 @@ public:
                 .id_type = CAN_STANDARD_IDENTIFIER,
                 .dlc = CAN_DATALENGTH_ACTUATOR_CURRENT
             };
-            actuator_controller::can_format_current tmp_cur = actuator_controller::can_format_current(message.current[1], message.current[0], message.current[2], message.connect);
+            actuator_controller::can_format_current tmp_cur = actuator_controller::can_format_current(message.current[0], message.current[1], message.current[2], message.connect);
             memcpy(can_frame_actuator_current.data, &tmp_cur, CAN_DATALENGTH_ACTUATOR_CURRENT);
 
             can_send(dev, &can_frame_actuator_encoder, K_MSEC(100), nullptr, nullptr);

--- a/lexxpluss_apps/src/rosserial_actuator.hpp
+++ b/lexxpluss_apps/src/rosserial_actuator.hpp
@@ -31,9 +31,9 @@
 #include <drivers/can.h>
 #include "actuator_controller.hpp"
 
-#define CAN_ID_ACTUATOR_CONTROL 0x208 //based on saito-san's CAN ID assignment
-#define CAN_ID_ACTUATOR_ENCODER 0x209 //based on saito-san's CAN ID assignment
-#define CAN_ID_ACTUATOR_CURRENT 0x20a //based on saito-san's CAN ID assignment
+#define CAN_ID_ACTUATOR_CONTROL 0x208 // based on saito-san's CAN ID assignment
+#define CAN_ID_ACTUATOR_ENCODER 0x209 // based on saito-san's CAN ID assignment
+#define CAN_ID_ACTUATOR_CURRENT 0x20a // based on saito-san's CAN ID assignment
 #define CAN_DATALENGTH_ACTUATOR_ENCODER 6
 #define CAN_DATALENGTH_ACTUATOR_CURRENT 8
 
@@ -47,13 +47,13 @@ k_msgq msgq_can_actuator_control;
 class ros_actuator {
 public:
     int init() {
-        //can device bind
+        // can device bind
         k_msgq_init(&msgq_can_actuator_control, msgq_can_actuator_control_buffer, sizeof(actuator_controller::can_format_control), 8);
         dev = device_get_binding("CAN_2");
         if (!device_is_ready(dev))
             return -1;
 
-        //setup can filter
+        // setup can filter
         static const zcan_filter filter_actuator_control{
             .id{CAN_ID_ACTUATOR_CONTROL},
             .rtr{CAN_DATAFRAME},
@@ -65,7 +65,7 @@ public:
         return 0;
     }
     void poll() {
-        //send to IPC of sensor informations
+        // send to IPC of sensor informations
         actuator_controller::msg message;
         while (k_msgq_get(&actuator_controller::msgq, &message, K_NO_WAIT) == 0) {
 
@@ -93,7 +93,7 @@ public:
             can_send(dev, &can_frame_actuator_current, K_MSEC(100), nullptr, nullptr);
         }
 
-        //receive from IPC of motion control
+        // receive from IPC of motion control
         while (k_msgq_get(&msgq_can_actuator_control, &frame_cntl, K_NO_WAIT) == 0) {
             msg_cntl = actuator_controller::msg_control(frame_cntl);
             while (k_msgq_put(&actuator_controller::msgq_control, &msg_cntl, K_NO_WAIT) != 0)

--- a/lexxpluss_apps/src/rosserial_actuator.hpp
+++ b/lexxpluss_apps/src/rosserial_actuator.hpp
@@ -26,18 +26,15 @@
 #pragma once
 
 #include <zephyr.h>
+#include <device.h>
 #include <drivers/gpio.h>
 #include <drivers/can.h>
-#include "ros/node_handle.h"
-#include "std_msgs/Float32MultiArray.h"
-#include "std_msgs/Int32MultiArray.h"
-#include "lexxauto_msgs/LinearActuatorControlArray.h"
 #include "actuator_controller.hpp"
 
 #define CAN_ID_ACTUATOR_CONTROL 0x208 //based on saito-san's CAN ID assignment
 #define CAN_ID_ACTUATOR_ENCODER 0x209 //based on saito-san's CAN ID assignment
 #define CAN_ID_ACTUATOR_CURRENT 0x20a //based on saito-san's CAN ID assignment
-#define CAN_DATALENGTH_ACTUATOR_CONTROL 6
+#define CAN_DATALENGTH_ACTUATOR_CONTROL 6 //sizeof(actuator_controller::can_format_control)
 #define CAN_DATALENGTH_ACTUATOR_ENCODER 6
 #define CAN_DATALENGTH_ACTUATOR_CURRENT 8
 
@@ -45,21 +42,14 @@
 
 namespace lexxhard {
 
-char __aligned(4) msgq_can_actuator_control_buffer[8 * sizeof (ms)];
-
+char __aligned(4) msgq_can_actuator_control_buffer[8 * CAN_DATALENGTH_ACTUATOR_CONTROL];
+k_msgq msgq_can_actuator_control;
 
 class ros_actuator {
 public:
     int init() {
-        // msg_encoder.data = msg_encoder_data;
-        // msg_encoder.data_length = sizeof msg_encoder_data / sizeof msg_encoder_data[0];
-        // msg_connection.data = msg_connection_data;
-        // msg_connection.data_length = sizeof msg_connection_data / sizeof msg_connection_data[0];
-        // msg_current.data = msg_current_data;
-        // msg_current.data_length = sizeof msg_current_data / sizeof msg_current_data[0];
-
-        //can device bind`
-        k_msgq_init(&msgq_can_actuator_control, msgq_can_actuator_control_buffer, 8/*???*/, 8);
+        //can device bind
+        k_msgq_init(&msgq_can_actuator_control, msgq_can_actuator_control_buffer, CAN_DATALENGTH_ACTUATOR_CONTROL, 8);
         dev = device_get_binding("CAN_2");
         if (!device_is_ready(dev))
             return -1;
@@ -76,47 +66,32 @@ public:
         return 0;
     }
     void poll() {
-        zcan_frame can_frame_actuator_encoder{
-            .id = CAN_ID_ACTUATOR_ENCODER,
-            .rtr = CAN_DATAFRAME,
-            .id_type = CAN_STANDARD_IDENTIFIER,
-            .dlc = CAN_DATALENGTH_ACTUATOR_ENCODER
-        };
-        zcan_frame can_frame_actuator_current{
-            .id = CAN_ID_ACTUATOR_CURRENT,
-            .rtr = CAN_DATAFRAME,
-            .id_type = CAN_STANDARD_IDENTIFIER,
-            .dlc = CAN_DATALENGTH_ACTUATOR_CURRENT
-        };
-        //actuator_controller::can_format_encoder tmp_frame_encoder;
-        //actuator_controller::can_format_current tmp_frame_current;
         //send to IPC of sensor informations
         actuator_controller::msg message;
         while (k_msgq_get(&actuator_controller::msgq, &message, K_NO_WAIT) == 0) {
-            // ROS:[center,left,right], ROBOT:[left,center,right
-
-            /* memcpyなどを使って.dataにencoder=countなどを詰める。*/
 
 
+            // ROS:[center,left,right], ROBOT:[left,center,right]
+            zcan_frame can_frame_actuator_encoder{
+                .id = CAN_ID_ACTUATOR_ENCODER,
+                .rtr = CAN_DATAFRAME,
+                .id_type = CAN_STANDARD_IDENTIFIER,
+                .dlc = CAN_DATALENGTH_ACTUATOR_ENCODER
+            };
+            actuator_controller::can_format_encoder tmp_enc = actuator_controller::can_format_encoder(message.encoder_count[1], message.encoder_count[0], message.encoder_count[2]);
+            memcpy(can_frame_actuator_encoder.data, &tmp_enc, CAN_DATALENGTH_ACTUATOR_ENCODER);
 
+            zcan_frame can_frame_actuator_current{
+                .id = CAN_ID_ACTUATOR_CURRENT,
+                .rtr = CAN_DATAFRAME,
+                .id_type = CAN_STANDARD_IDENTIFIER,
+                .dlc = CAN_DATALENGTH_ACTUATOR_CURRENT
+            };
+            actuator_controller::can_format_current tmp_cur = actuator_controller::can_format_current(message.current[1], message.current[0], message.current[2], message.connect);
+            memcpy(can_frame_actuator_current.data, &tmp_cur, CAN_DATALENGTH_ACTUATOR_CURRENT);
 
-            // memcpy(can_frame_actuator_encoder.data, actuator_controller::can_format_encoder(message.encoder_count[1], message.encoder_count[0], message.encoder_count[2]);
-            // can_frame_actuator_current.data = actuator_controller::can_format_encoder(message.current[1], message.current[0], message.current[2]);
-            // frame_enc.encoder_count[0] = message.encoder_count[1];
-            // frame_enc.encoder_count[1] = message.encoder_count[0];
-            // frame_enc.encoder_count[2] = message.encoder_count[2];
-            //pub_encoder.publish(&msg_encoder);
-            frame_cur.connection_mv = message.connect * 1e-3f;
-            //pub_connection.publish(&msg_connection);
-            frame_cur.current_mv[0] = message.current[1] * 1e-3f;
-            frame_cur.current_mv[1] = message.current[0] * 1e-3f;
-            frame_cur.current_mv[2] = message.current[2] * 1e-3f;
-            //pub_current.publish(&msg_current);
-            
-            
             can_send(dev, &can_frame_actuator_encoder, K_MSEC(100), nullptr, nullptr);
             can_send(dev, &can_frame_actuator_current, K_MSEC(100), nullptr, nullptr);
-
         }
 
         //receive from IPC of motion control
@@ -127,58 +102,12 @@ public:
         }
     }
 private:
-
-    // static const zcan_frame can_frame_actuator_control{
-    //     .id = CAN_ID_ACTUATOR_CONTROL,
-    //     .rtr = CAN_DATAFRAME,
-    //     .id_type = CAN_STANDARD_IDENTIFIER,
-    //     .dlc = CAN_DATALENGTH_ACTUATOR_CONTROL
-    // };
-    // static const zcan_frame can_frame_actuator_encoder{
-    //     .id = CAN_ID_ACTUATOR_ENCODER,
-    //     .rtr = CAN_DATAFRAME,
-    //     .id_type = CAN_STANDARD_IDENTIFIER,
-    //     .dlc = CAN_DATALENGTH_ACTUATOR_ENCODER
-    // };
-    // static const zcan_frame can_frame_actuator_current{
-    //     .id = CAN_ID_ACTUATOR_CURRENT,
-    //     .rtr = CAN_DATAFRAME,
-    //     .id_type = CAN_STANDARD_IDENTIFIER,
-    //     .dlc = CAN_DATALENGTH_ACTUATOR_CURRENT
-    // };
-    
-    void callback_control(const lexxauto_msgs::LinearActuatorControlArray &req) {
-        actuator_controller::msg_control message;
-        // ROS:[center,left,right], ROBOT:[left,center,right]
-        message.actuators[0].direction = req.actuators[1].direction;
-        message.actuators[1].direction = req.actuators[0].direction;
-        message.actuators[2].direction = req.actuators[2].direction;
-        message.actuators[0].power = req.actuators[1].power;
-        message.actuators[1].power = req.actuators[0].power;
-        message.actuators[2].power = req.actuators[2].power;
-        while (k_msgq_put(&actuator_controller::msgq_control, &message, K_NO_WAIT) != 0)
-            k_msgq_purge(&actuator_controller::msgq_control);
-    }
-    //std_msgs::Int32MultiArray msg_encoder;
     actuator_controller::can_format_control frame_cntl;
-    //actuator_controller::can_format_current frame_cur;
-    //actuator_controller::can_format_encoder frame_enc;
     actuator_controller::msg_control msg_cntl;
     const device *dev{nullptr};
-
-    //std_msgs::Float32MultiArray msg_connection, msg_current;
-    //int32_t msg_encoder_data[3];
-    //float msg_connection_data[1], msg_current_data[3];
-    // ros::Publisher pub_encoder{"/body_control/encoder_count", &msg_encoder};
-    // ros::Publisher pub_connection{"/body_control/shelf_connection", &msg_connection};
-    // ros::Publisher pub_current{"/body_control/linear_actuator_current", &msg_current};
-    // ros::Subscriber<lexxauto_msgs::LinearActuatorControlArray, ros_actuator>
-    //     sub_control{"/body_control/linear_actuator", &ros_actuator::callback_control, this};
-
 };
 
-k_msgq msgq_can_actuator_control;
-
+//k_msgq msgq_can_actuator_control;
 }
 
 // vim: set expandtab shiftwidth=4:

--- a/lexxpluss_apps/src/rosserial_actuator.hpp
+++ b/lexxpluss_apps/src/rosserial_actuator.hpp
@@ -34,7 +34,6 @@
 #define CAN_ID_ACTUATOR_CONTROL 0x208 //based on saito-san's CAN ID assignment
 #define CAN_ID_ACTUATOR_ENCODER 0x209 //based on saito-san's CAN ID assignment
 #define CAN_ID_ACTUATOR_CURRENT 0x20a //based on saito-san's CAN ID assignment
-#define CAN_DATALENGTH_ACTUATOR_CONTROL 6 //sizeof(actuator_controller::can_format_control)
 #define CAN_DATALENGTH_ACTUATOR_ENCODER 6
 #define CAN_DATALENGTH_ACTUATOR_CURRENT 8
 
@@ -42,14 +41,14 @@
 
 namespace lexxhard {
 
-char __aligned(4) msgq_can_actuator_control_buffer[8 * CAN_DATALENGTH_ACTUATOR_CONTROL];
+char __aligned(4) msgq_can_actuator_control_buffer[8 * sizeof(actuator_controller::can_format_control)];
 k_msgq msgq_can_actuator_control;
 
 class ros_actuator {
 public:
     int init() {
         //can device bind
-        k_msgq_init(&msgq_can_actuator_control, msgq_can_actuator_control_buffer, CAN_DATALENGTH_ACTUATOR_CONTROL, 8);
+        k_msgq_init(&msgq_can_actuator_control, msgq_can_actuator_control_buffer, sizeof(actuator_controller::can_format_control), 8);
         dev = device_get_binding("CAN_2");
         if (!device_is_ready(dev))
             return -1;
@@ -107,7 +106,6 @@ private:
     const device *dev{nullptr};
 };
 
-//k_msgq msgq_can_actuator_control;
 }
 
 // vim: set expandtab shiftwidth=4:

--- a/lexxpluss_apps/src/rosserial_actuator.hpp
+++ b/lexxpluss_apps/src/rosserial_actuator.hpp
@@ -26,45 +26,127 @@
 #pragma once
 
 #include <zephyr.h>
+#include <drivers/gpio.h>
+#include <drivers/can.h>
 #include "ros/node_handle.h"
 #include "std_msgs/Float32MultiArray.h"
 #include "std_msgs/Int32MultiArray.h"
 #include "lexxauto_msgs/LinearActuatorControlArray.h"
 #include "actuator_controller.hpp"
 
+#define CAN_ID_ACTUATOR_CONTROL 0x208 //based on saito-san's CAN ID assignment
+#define CAN_ID_ACTUATOR_ENCODER 0x209 //based on saito-san's CAN ID assignment
+#define CAN_ID_ACTUATOR_CURRENT 0x20a //based on saito-san's CAN ID assignment
+#define CAN_DATALENGTH_ACTUATOR_CONTROL 6
+#define CAN_DATALENGTH_ACTUATOR_ENCODER 6
+#define CAN_DATALENGTH_ACTUATOR_CURRENT 8
+
+
+
 namespace lexxhard {
+
+char __aligned(4) msgq_can_actuator_control_buffer[8 * sizeof (ms)];
+
 
 class ros_actuator {
 public:
-    void init(ros::NodeHandle &nh) {
-        nh.advertise(pub_encoder);
-        nh.advertise(pub_connection);
-        nh.advertise(pub_current);
-        nh.subscribe(sub_control);
-        msg_encoder.data = msg_encoder_data;
-        msg_encoder.data_length = sizeof msg_encoder_data / sizeof msg_encoder_data[0];
-        msg_connection.data = msg_connection_data;
-        msg_connection.data_length = sizeof msg_connection_data / sizeof msg_connection_data[0];
-        msg_current.data = msg_current_data;
-        msg_current.data_length = sizeof msg_current_data / sizeof msg_current_data[0];
+    int init() {
+        // msg_encoder.data = msg_encoder_data;
+        // msg_encoder.data_length = sizeof msg_encoder_data / sizeof msg_encoder_data[0];
+        // msg_connection.data = msg_connection_data;
+        // msg_connection.data_length = sizeof msg_connection_data / sizeof msg_connection_data[0];
+        // msg_current.data = msg_current_data;
+        // msg_current.data_length = sizeof msg_current_data / sizeof msg_current_data[0];
+
+        //can device bind`
+        k_msgq_init(&msgq_can_actuator_control, msgq_can_actuator_control_buffer, 8/*???*/, 8);
+        dev = device_get_binding("CAN_2");
+        if (!device_is_ready(dev))
+            return -1;
+
+        //setup can filter
+        static const zcan_filter filter_actuator_control{
+            .id{CAN_ID_ACTUATOR_CONTROL},
+            .rtr{CAN_DATAFRAME},
+            .id_type{CAN_STANDARD_IDENTIFIER},
+            .id_mask{0x7ff},
+            .rtr_mask{1}
+        };
+        can_attach_msgq(dev, &msgq_can_actuator_control, &filter_actuator_control);
+        return 0;
     }
     void poll() {
+        zcan_frame can_frame_actuator_encoder{
+            .id = CAN_ID_ACTUATOR_ENCODER,
+            .rtr = CAN_DATAFRAME,
+            .id_type = CAN_STANDARD_IDENTIFIER,
+            .dlc = CAN_DATALENGTH_ACTUATOR_ENCODER
+        };
+        zcan_frame can_frame_actuator_current{
+            .id = CAN_ID_ACTUATOR_CURRENT,
+            .rtr = CAN_DATAFRAME,
+            .id_type = CAN_STANDARD_IDENTIFIER,
+            .dlc = CAN_DATALENGTH_ACTUATOR_CURRENT
+        };
+        //actuator_controller::can_format_encoder tmp_frame_encoder;
+        //actuator_controller::can_format_current tmp_frame_current;
+        //send to IPC of sensor informations
         actuator_controller::msg message;
         while (k_msgq_get(&actuator_controller::msgq, &message, K_NO_WAIT) == 0) {
-            // ROS:[center,left,right], ROBOT:[left,center,right]
-            msg_encoder.data[0] = message.encoder_count[1];
-            msg_encoder.data[1] = message.encoder_count[0];
-            msg_encoder.data[2] = message.encoder_count[2];
-            pub_encoder.publish(&msg_encoder);
-            msg_connection.data[0] = message.connect * 1e-3f;
-            pub_connection.publish(&msg_connection);
-            msg_current.data[0] = message.current[1] * 1e-3f;
-            msg_current.data[1] = message.current[0] * 1e-3f;
-            msg_current.data[2] = message.current[2] * 1e-3f;
-            pub_current.publish(&msg_current);
+            // ROS:[center,left,right], ROBOT:[left,center,right
+
+            /* memcpyなどを使って.dataにencoder=countなどを詰める。*/
+
+
+
+
+            // memcpy(can_frame_actuator_encoder.data, actuator_controller::can_format_encoder(message.encoder_count[1], message.encoder_count[0], message.encoder_count[2]);
+            // can_frame_actuator_current.data = actuator_controller::can_format_encoder(message.current[1], message.current[0], message.current[2]);
+            // frame_enc.encoder_count[0] = message.encoder_count[1];
+            // frame_enc.encoder_count[1] = message.encoder_count[0];
+            // frame_enc.encoder_count[2] = message.encoder_count[2];
+            //pub_encoder.publish(&msg_encoder);
+            frame_cur.connection_mv = message.connect * 1e-3f;
+            //pub_connection.publish(&msg_connection);
+            frame_cur.current_mv[0] = message.current[1] * 1e-3f;
+            frame_cur.current_mv[1] = message.current[0] * 1e-3f;
+            frame_cur.current_mv[2] = message.current[2] * 1e-3f;
+            //pub_current.publish(&msg_current);
+            
+            
+            can_send(dev, &can_frame_actuator_encoder, K_MSEC(100), nullptr, nullptr);
+            can_send(dev, &can_frame_actuator_current, K_MSEC(100), nullptr, nullptr);
+
+        }
+
+        //receive from IPC of motion control
+        while (k_msgq_get(&msgq_can_actuator_control, &frame_cntl, K_NO_WAIT) == 0) {
+            msg_cntl = actuator_controller::msg_control(frame_cntl);
+            while (k_msgq_put(&actuator_controller::msgq_control, &msg_cntl, K_NO_WAIT) != 0)
+                k_msgq_purge(&actuator_controller::msgq_control);
         }
     }
 private:
+
+    // static const zcan_frame can_frame_actuator_control{
+    //     .id = CAN_ID_ACTUATOR_CONTROL,
+    //     .rtr = CAN_DATAFRAME,
+    //     .id_type = CAN_STANDARD_IDENTIFIER,
+    //     .dlc = CAN_DATALENGTH_ACTUATOR_CONTROL
+    // };
+    // static const zcan_frame can_frame_actuator_encoder{
+    //     .id = CAN_ID_ACTUATOR_ENCODER,
+    //     .rtr = CAN_DATAFRAME,
+    //     .id_type = CAN_STANDARD_IDENTIFIER,
+    //     .dlc = CAN_DATALENGTH_ACTUATOR_ENCODER
+    // };
+    // static const zcan_frame can_frame_actuator_current{
+    //     .id = CAN_ID_ACTUATOR_CURRENT,
+    //     .rtr = CAN_DATAFRAME,
+    //     .id_type = CAN_STANDARD_IDENTIFIER,
+    //     .dlc = CAN_DATALENGTH_ACTUATOR_CURRENT
+    // };
+    
     void callback_control(const lexxauto_msgs::LinearActuatorControlArray &req) {
         actuator_controller::msg_control message;
         // ROS:[center,left,right], ROBOT:[left,center,right]
@@ -77,16 +159,25 @@ private:
         while (k_msgq_put(&actuator_controller::msgq_control, &message, K_NO_WAIT) != 0)
             k_msgq_purge(&actuator_controller::msgq_control);
     }
-    std_msgs::Int32MultiArray msg_encoder;
-    std_msgs::Float32MultiArray msg_connection, msg_current;
-    int32_t msg_encoder_data[3];
-    float msg_connection_data[1], msg_current_data[3];
-    ros::Publisher pub_encoder{"/body_control/encoder_count", &msg_encoder};
-    ros::Publisher pub_connection{"/body_control/shelf_connection", &msg_connection};
-    ros::Publisher pub_current{"/body_control/linear_actuator_current", &msg_current};
-    ros::Subscriber<lexxauto_msgs::LinearActuatorControlArray, ros_actuator>
-        sub_control{"/body_control/linear_actuator", &ros_actuator::callback_control, this};
+    //std_msgs::Int32MultiArray msg_encoder;
+    actuator_controller::can_format_control frame_cntl;
+    //actuator_controller::can_format_current frame_cur;
+    //actuator_controller::can_format_encoder frame_enc;
+    actuator_controller::msg_control msg_cntl;
+    const device *dev{nullptr};
+
+    //std_msgs::Float32MultiArray msg_connection, msg_current;
+    //int32_t msg_encoder_data[3];
+    //float msg_connection_data[1], msg_current_data[3];
+    // ros::Publisher pub_encoder{"/body_control/encoder_count", &msg_encoder};
+    // ros::Publisher pub_connection{"/body_control/shelf_connection", &msg_connection};
+    // ros::Publisher pub_current{"/body_control/linear_actuator_current", &msg_current};
+    // ros::Subscriber<lexxauto_msgs::LinearActuatorControlArray, ros_actuator>
+    //     sub_control{"/body_control/linear_actuator", &ros_actuator::callback_control, this};
+
 };
+
+k_msgq msgq_can_actuator_control;
 
 }
 

--- a/lexxpluss_apps/src/rosserial_actuator_service.hpp
+++ b/lexxpluss_apps/src/rosserial_actuator_service.hpp
@@ -1,73 +1,73 @@
-/*
- * Copyright (c) 2022, LexxPluss Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// /*
+//  * Copyright (c) 2022, LexxPluss Inc.
+//  * All rights reserved.
+//  *
+//  * Redistribution and use in source and binary forms, with or without
+//  * modification, are permitted provided that the following conditions are met:
+//  *
+//  * 1. Redistributions of source code must retain the above copyright notice,
+//  *    this list of conditions and the following disclaimer.
+//  * 2. Redistributions in binary form must reproduce the above copyright notice,
+//  *    this list of conditions and the following disclaimer in the documentation
+//  *    and/or other materials provided with the distribution.
+//  *
+//  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//  * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+//  * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//  */
 
-#pragma once
+// #pragma once
 
-#include <zephyr.h>
-#include "ros/node_handle.h"
-#include "lexxauto_msgs/InitLinearActuator.h"
-#include "lexxauto_msgs/LinearActuatorLocation.h"
-#include "actuator_controller.hpp"
+// #include <zephyr.h>
+// #include "ros/node_handle.h"
+// #include "lexxauto_msgs/InitLinearActuator.h"
+// #include "lexxauto_msgs/LinearActuatorLocation.h"
+// #include "actuator_controller.hpp"
 
-namespace lexxhard {
+// namespace lexxhard {
 
-class ros_actuator_service {
-public:
-    void init(ros::NodeHandle &nh) {
-        nh.advertiseService(service_location);
-        nh.advertiseService(service_init);
-    }
-private:
-    void callback_location(const lexxauto_msgs::LinearActuatorLocationRequest &req, lexxauto_msgs::LinearActuatorLocationResponse &res) {
-        // ROS:[center,left,right], ROBOT:[left,center,right]
-        uint8_t location[3]{
-            req.location.data[1],
-            req.location.data[0],
-            req.location.data[2]
-        };
-        uint8_t power[3]{
-            req.power.data[1],
-            req.power.data[0],
-            req.power.data[2]
-        };
-        uint8_t detail[3];
-        res.success = actuator_controller::to_location(location, power, detail) == 0;
-        res.detail.data[0] = detail[1];
-        res.detail.data[1] = detail[0];
-        res.detail.data[2] = detail[2];
-        res.detail.data_length = sizeof detail / sizeof detail[0];
-    }
-    void callback_init(const lexxauto_msgs::InitLinearActuatorRequest &req, lexxauto_msgs::InitLinearActuatorResponse &res) {
-        res.success = actuator_controller::init_location() == 0;
-    }
-    ros::ServiceServer<lexxauto_msgs::LinearActuatorLocationRequest, lexxauto_msgs::LinearActuatorLocationResponse, ros_actuator_service>
-        service_location{"/body_control/linear_actuator_location", &ros_actuator_service::callback_location, this};
-    ros::ServiceServer<lexxauto_msgs::InitLinearActuatorRequest, lexxauto_msgs::InitLinearActuatorResponse, ros_actuator_service>
-        service_init{"/body_control/init_linear_actuator", &ros_actuator_service::callback_init, this};
-};
+// class ros_actuator_service {
+// public:
+//     void init(ros::NodeHandle &nh) {
+//         nh.advertiseService(service_location);
+//         nh.advertiseService(service_init);
+//     }
+// private:
+//     void callback_location(const lexxauto_msgs::LinearActuatorLocationRequest &req, lexxauto_msgs::LinearActuatorLocationResponse &res) {
+//         // ROS:[center,left,right], ROBOT:[left,center,right]
+//         uint8_t location[3]{
+//             req.location.data[1],
+//             req.location.data[0],
+//             req.location.data[2]
+//         };
+//         uint8_t power[3]{
+//             req.power.data[1],
+//             req.power.data[0],
+//             req.power.data[2]
+//         };
+//         uint8_t detail[3];
+//         res.success = actuator_controller::to_location(location, power, detail) == 0;
+//         res.detail.data[0] = detail[1];
+//         res.detail.data[1] = detail[0];
+//         res.detail.data[2] = detail[2];
+//         res.detail.data_length = sizeof detail / sizeof detail[0];
+//     }
+//     void callback_init(const lexxauto_msgs::InitLinearActuatorRequest &req, lexxauto_msgs::InitLinearActuatorResponse &res) {
+//         res.success = actuator_controller::init_location() == 0;
+//     }
+//     ros::ServiceServer<lexxauto_msgs::LinearActuatorLocationRequest, lexxauto_msgs::LinearActuatorLocationResponse, ros_actuator_service>
+//         service_location{"/body_control/linear_actuator_location", &ros_actuator_service::callback_location, this};
+//     ros::ServiceServer<lexxauto_msgs::InitLinearActuatorRequest, lexxauto_msgs::InitLinearActuatorResponse, ros_actuator_service>
+//         service_init{"/body_control/init_linear_actuator", &ros_actuator_service::callback_init, this};
+// };
 
-}
+// }
 
-// vim: set expandtab shiftwidth=4:
+// // vim: set expandtab shiftwidth=4:

--- a/lexxpluss_apps/src/rosserial_service.cpp
+++ b/lexxpluss_apps/src/rosserial_service.cpp
@@ -1,64 +1,64 @@
-/*
- * Copyright (c) 2022, LexxPluss Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// /*
+//  * Copyright (c) 2022, LexxPluss Inc.
+//  * All rights reserved.
+//  *
+//  * Redistribution and use in source and binary forms, with or without
+//  * modification, are permitted provided that the following conditions are met:
+//  *
+//  * 1. Redistributions of source code must retain the above copyright notice,
+//  *    this list of conditions and the following disclaimer.
+//  * 2. Redistributions in binary form must reproduce the above copyright notice,
+//  *    this list of conditions and the following disclaimer in the documentation
+//  *    and/or other materials provided with the distribution.
+//  *
+//  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//  * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+//  * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//  */
 
-#include "rosserial_hardware_zephyr.hpp"
-#include "rosserial_actuator_service.hpp"
-#include "rosserial_service.hpp"
+// #include "rosserial_hardware_zephyr.hpp"
+// #include "rosserial_actuator_service.hpp"
+// #include "rosserial_service.hpp"
 
-namespace lexxhard::rosserial_service {
+// namespace lexxhard::rosserial_service {
 
-class {
-public:
-    int init() {
-        nh.initNode(const_cast<char*>("UART_2"));
-        actuator_service.init(nh);
-        return 0;
-    }
-    void run() {
-        while (true) {
-            nh.spinOnce();
-            k_usleep(1);
-        }
-    }
-private:
-    ros::NodeHandle nh;
-    ros_actuator_service actuator_service;
-} impl;
+// class {
+// public:
+//     int init() {
+//         nh.initNode(const_cast<char*>("UART_2"));
+//         actuator_service.init(nh);
+//         return 0;
+//     }
+//     void run() {
+//         while (true) {
+//             nh.spinOnce();
+//             k_usleep(1);
+//         }
+//     }
+// private:
+//     ros::NodeHandle nh;
+//     ros_actuator_service actuator_service;
+// } impl;
 
-void init()
-{
-    impl.init();
-}
+// void init()
+// {
+//     impl.init();
+// }
 
-void run(void *p1, void *p2, void *p3)
-{
-    impl.run();
-}
+// void run(void *p1, void *p2, void *p3)
+// {
+//     impl.run();
+// }
 
-k_thread thread;
+// k_thread thread;
 
-}
+// }
 
-// vim: set expandtab shiftwidth=4:
+// // vim: set expandtab shiftwidth=4:

--- a/lexxpluss_apps/src/rosserial_service.hpp
+++ b/lexxpluss_apps/src/rosserial_service.hpp
@@ -1,38 +1,38 @@
-/*
- * Copyright (c) 2022, LexxPluss Inc.
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are met:
- *
- * 1. Redistributions of source code must retain the above copyright notice,
- *    this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright notice,
- *    this list of conditions and the following disclaimer in the documentation
- *    and/or other materials provided with the distribution.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
- * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
- * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
- * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
- * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
- * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
- * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
- * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
+// /*
+//  * Copyright (c) 2022, LexxPluss Inc.
+//  * All rights reserved.
+//  *
+//  * Redistribution and use in source and binary forms, with or without
+//  * modification, are permitted provided that the following conditions are met:
+//  *
+//  * 1. Redistributions of source code must retain the above copyright notice,
+//  *    this list of conditions and the following disclaimer.
+//  * 2. Redistributions in binary form must reproduce the above copyright notice,
+//  *    this list of conditions and the following disclaimer in the documentation
+//  *    and/or other materials provided with the distribution.
+//  *
+//  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+//  * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+//  * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+//  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+//  * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+//  * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+//  * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+//  * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+//  * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+//  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//  */
 
-#pragma once
+// #pragma once
 
-#include <zephyr.h>
+// #include <zephyr.h>
 
-namespace lexxhard::rosserial_service {
+// namespace lexxhard::rosserial_service {
 
-void init();
-void run(void *p1, void *p2, void *p3);
-extern k_thread thread;
+// void init();
+// void run(void *p1, void *p2, void *p3);
+// extern k_thread thread;
 
-}
+// }
 
-// vim: set expandtab shiftwidth=4:
+// // vim: set expandtab shiftwidth=4:


### PR DESCRIPTION
HWDEV-1250
以下変更が含まれていることが期待値です。
ビルドが通ることを確認しています。

### ROSSerial→CAN化
各種ROSSerial関連コードを削除しCAN化しています。
またファイルのリネームや削除などは別PRとする予定です。

### サイドエンコーダの削除
左右アクチュエータのエンコーダはV7から回路構成が変更となりソフトウェアエンコーダとなります。ただし実装優先順位を下げています。
そこで、本PRでは純粋にそれらのエンコーダの使用を削除しています。


### 電流センサパラメータ
V6世代ボード
![image](https://github.com/LexxPluss/LexxHard-SensorControlBoard-Firmware/assets/45596573/5f920a7a-352a-404a-a958-478d7410d7bc)

V7世代ボード
![image](https://github.com/LexxPluss/LexxHard-SensorControlBoard-Firmware/assets/45596573/d42952f8-d789-41c8-9eaa-abd0e903f866)
以下のように変更しています。
| param | V6 | V7 | note |
|-|-|-|-|
| AMP_GAIN | 20.0f | 50.0f| 電流センサICをゲインが違うものに変更 |
| VOLLTAGE _ DIVIDER | 3.0f | 1.0f | 謎の分圧を廃止 |
| SHUNT_REGISTER | 0.1f | 0.01f | シャント抵抗の値を変更 | 
