### PR TITLE
HWDEV-1494 led_controller have msg_led no declared variant

### DIFF
--- a/lexxpluss_apps/src/rosserial_led.hpp
+++ b/lexxpluss_apps/src/rosserial_led.hpp
@@ -36,7 +36,7 @@
 namespace lexxhard {
 
 char __aligned(4) msgq_led_buffer[8 * sizeof (led_controller::msg)];
-
+k_msgq msgq_can_led;
 
 class can_led {
 public:
@@ -73,8 +73,6 @@ private:
     led_controller::msg can2led;
     const device *dev{nullptr};
 };
-
-k_msgq msgq_can_led;
 }
 
 // vim: set expandtab shiftwidth=4:

--- a/lexxpluss_apps/src/rosserial_led.hpp
+++ b/lexxpluss_apps/src/rosserial_led.hpp
@@ -35,7 +35,7 @@
 
 namespace lexxhard {
 
-char __aligned(4) msgq_led_buffer[8 * sizeof (msg_led)];
+char __aligned(4) msgq_led_buffer[8 * sizeof (led_controller::msg)];
 
 
 class can_led {
@@ -43,7 +43,7 @@ public:
     int init()
     {
         //can device bind`
-        k_msgq_init(&msgq_can_led, msgq_led_buffer, sizeof (msg_led), 8);
+        k_msgq_init(&msgq_can_led, msgq_led_buffer, sizeof (led_controller::msg), 8);
         dev = device_get_binding("CAN_2");
         if (!device_is_ready(dev))
             return -1;


### PR DESCRIPTION
以下不自然な点があったので、三浦さんにチェックをお願いしたところ編集したコードが呼び出されていないためにエラーを見逃していました。呼び出した状態でエラーが出ないように修正しました。

経緯：
過去の自分のコードを見ていて
https://github.com/LexxPluss/LexxHard-SensorControlBoard-Firmware/pull/3/files#diff-8c494f9b39c8d2157023b59ba765dd1cdd351015f1615d94314d2f666d146572R38
このmsg_ledの定義を探そうとしましたが、見つかリませんでした。

修正箇所：
・msg_led -> led_controller::msgに修正
・msgq_can_led の場所を修正