### PR TITLE
HWDEV-1560 changed debug UARTnumber and change some commentouted code on actuato…

### DIFF
--- a/lexxpluss_apps/src/actuator_controller.cpp
+++ b/lexxpluss_apps/src/actuator_controller.cpp
@@ -151,12 +151,12 @@ public:
             mm_per_pulse = 50.0f / 1054.0f;
             break;
         case POS::LEFT:
-            // result = enc.init(TIM3);
-            // mm_per_pulse = 50.0f / 1054.0f;
+            result = enc.init(TIM3);
+            mm_per_pulse = 50.0f / 1054.0f;
             break;
         case POS::RIGHT:
-            // result = enc.init(TIM1);
-            // mm_per_pulse = 50.0f / 1054.0f;
+            result = enc.init(TIM1);
+            mm_per_pulse = 50.0f / 1054.0f;
             break;
         }
         reset_pulse();
@@ -214,16 +214,16 @@ public:
             pin[1] = 2;
             break;
         case POS::LEFT:
-            // dev[0] = device_get_binding("PWM_8");
-            // dev[1] = dev[0];
-            // pin[0] = 1;
-            // pin[1] = 2;
+            dev[0] = device_get_binding("PWM_8");
+            dev[1] = dev[0];
+            pin[0] = 1;
+            pin[1] = 2;
             break;
         case POS::RIGHT:
-            // dev[0] = device_get_binding("PWM_2");
-            // dev[1] = dev[0];
-            // pin[0] = 3;
-            // pin[1] = 4;
+            dev[0] = device_get_binding("PWM_2");
+            dev[1] = dev[0];
+            pin[0] = 3;
+            pin[1] = 4;
             break;
         }
         if (!device_is_ready(dev[0]) || !device_is_ready(dev[1]))


### PR DESCRIPTION
…r_controller.cpp because UART not works when commentouted, that initialization code is mandatory

HWDEV-1560

アクチュエータのコードにて初期化されていないポインタが存在しました。

V7で変更されるUSARTポートをいじった際に上記問題に伴う不具合が顕現し、コンパイルエラーはでないもののHardFaultを起こしていました。
初期化コードはもともと存在したものの、V7にて一部変更が入る予定のため、一度コメントアウトしたものでした。
とりあえず現状は初期化を復活させることとして動作することを確認しました。
