### PR TITLE
HWDEV-1935 enable lockdown

### DIFF
--- a/lexxpluss_apps/src/board_controller.cpp
+++ b/lexxpluss_apps/src/board_controller.cpp
@@ -921,13 +921,7 @@ private:
         wheel_poweroff = msg.ros_wheel_power_off;
 
         // heartbeat is not timeout means heartbeat is detected
-        if (ros_heartbeat_timeout == false) {
-            heartbeat_detect = true;
-            //LOG_INF("ROS Heartbeat Detected");
-        } else {
-            heartbeat_detect = false;
-            LOG_ERR("ROS Heartbeat Timeout");
-        }
+        heartbeat_detect |= !ros_heartbeat_timeout;
     }
     bool heartbeat_detect{false}, ros_heartbeat_timeout{false}, emergency_stop{true}, power_off{false},
         wheel_poweroff{false};
@@ -1171,6 +1165,9 @@ private:
                 set_new_state(POWER_STATE::STANDBY);
             } else if (mbd.emergency_stop_from_ros()) {
                 LOG_DBG("receive emergency stop from ROS\n");
+                set_new_state(POWER_STATE::STANDBY);
+            } else if (mbd.is_dead()) {
+                LOG_INF("mainboard is dead\n");
                 set_new_state(POWER_STATE::STANDBY);
             } else if (mc.is_plugged()) {
                 LOG_DBG("plugged to manual charger\n");


### PR DESCRIPTION
Ref: [HWDEV-1935](https://lexxpluss.atlassian.net/browse/HWDEV-1935)

This PR is motivated to enable lockdown. In the original implementation, there ware two issues as followings.

* `heartbeat_detect` is cleared when `ros_heartbeat_timeout` is true. This means that `mbd.is_dead()` always return false.
* There aren't any transitions from NORMAL to LOCKDOWN.

To fix above issues, this PR added the followings.

* Don't clear `heartbeat_detect` even if `ros_heartbeat_timeout` is true.
* Add a transition from NORMAL to STANDBY. The motivation of this modification is that STANDBY has transitions to LOCKDOWN. I think this transition is redundant. But I mimicked the same case of AUTOCHARGE for now. I have motivation to re-implement this state. 

This PR is check in ES2 and It worked expectedly.

[HWDEV-1935]: https://lexxpluss.atlassian.net/browse/HWDEV-1935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ