### PR TITLE
HWDEV-1965 use can_frame to retrieve data from can

### DIFF
--- a/lexxpluss_apps/src/zcan_led.hpp
+++ b/lexxpluss_apps/src/zcan_led.hpp
@@ -66,7 +66,14 @@ public:
 
     void poll()
     {
-        while (k_msgq_get(&msgq_can_led, &can_led_frame, K_NO_WAIT) == 0) {
+        struct can_frame can_frame;
+        while (k_msgq_get(&msgq_can_led, &can_frame, K_NO_WAIT) == 0) {
+            can_led_frame.pattern = can_frame.data[0];
+            can_led_frame.count_per_minutes = (can_frame.data[1] << 8) | can_frame.data[2];
+            can_led_frame.rgb[0] = can_frame.data[3];
+            can_led_frame.rgb[1] = can_frame.data[4];
+            can_led_frame.rgb[2] = can_frame.data[5];
+
             can2led = led_controller::msg(can_led_frame);
             while (k_msgq_put(&led_controller::msgq, &can2led, K_NO_WAIT) != 0)
                 k_msgq_purge(&led_controller::msgq);


### PR DESCRIPTION
Ref: [HWDEV-1965](https://lexxpluss.atlassian.net/browse/HWDEV-1965)

This PR is motivated  to fix strage led color issue. This issue was caused by not using `can_frame` structure to retrieve data from can. This PR modified followings to fix this issue.

* Use `can_frame` structure to retrieve data from can.
* Copy can payload to `can_led_frame` structure

This PR is checked in ES2 environmet. And I found that it works correctly. 

[HWDEV-1965]: https://lexxpluss.atlassian.net/browse/HWDEV-1965?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ