### PR TITLE
Hwdev 1966 make auto charging enable

### DIFF
--- a/lexxpluss_apps/src/zcan_board.hpp
+++ b/lexxpluss_apps/src/zcan_board.hpp
@@ -93,7 +93,7 @@ public:
             packedData[2] = message.shutdown_reason;
             packedData[3] = message.charge_heartbeat_delay;
 
-            uint16_t scaled_voltage = (uint16_t)(message.charge_connector_voltage * 1000);
+            uint16_t scaled_voltage = static_cast<uint16_t>(message.charge_connector_voltage); //unit is mv
 
             packedData[4] = (uint8_t)(scaled_voltage >> 8);   // Upper Byte
             packedData[5] = (uint8_t)(scaled_voltage & 0xFF); // Lower Byte


### PR DESCRIPTION
Ref: [HWDEV-1966](https://lexxpluss.atlassian.net/browse/HWDEV-1966)

This PR is motivated to fix auto charging feature. This PR contains following modifications.

* Specify correct context to uart isr instead of NULL,
*  Fix wrong callback names
* Add a timer whose name is `last_serial_recv_time` to detect failing of IrDA communications
* Decode all data which are stored in queue

And this PR was checked in real robot.

[HWDEV-1966]: https://lexxpluss.atlassian.net/browse/HWDEV-1966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ