### PR TITLE
HWDEV-2025 fix counting items in ring buffer

### DIFF
--- a/lexxpluss_apps/src/pgv_controller.cpp
+++ b/lexxpluss_apps/src/pgv_controller.cpp
@@ -220,7 +220,10 @@ private:
         return check == buf[tail];
     }
     uint32_t rb_count(const ring_buf *rb) const {
-        return rb->get_tail - rb->get_head;
+        // ring_buf_size_get require `non const` pointer to ring_buf
+        // so, use const_cast to remove const qualifier
+        auto non_const_rb = const_cast<ring_buf*>(rb); 
+        return ring_buf_size_get(non_const_rb);
     }
     void send(const uint8_t *buf, uint32_t length) {
         if (device_is_ready(dev_485)) {


### PR DESCRIPTION
Ref: [HWDEV-2025](https://lexxpluss.atlassian.net/browse/HWDEV-2025)

This PR is motivated to fix pgv tape detection frequency issue. This was caused by timeout occurring in the communication between SCB and PGV Camera. The cause of this timeout is wrong implementation of counting items in queue which is used as a buffer for RS485 receiver.  SCB waits until the count of items in queue reaching expected value. But the current implementation cannot count items in queue correctly. So timeout occurs every time.

This PR fixes above issue by using `ring_buf_size_get` function to count items in queue.  `ring_buf_size_get` require a **non const** pointer to `struct ring_buf`. So this PR add a const cast to remove const qualifier. I think that we can recognize `ring_buf_size_get` const function.

This PR is checked in real robot with https://github.com/LexxPluss/LexxHard-SCBDriver/pull/7 . The following video shows that pgv detection works correctly.
[Screencast from 2024-06-25 14-35-29.webm](https://github.com/LexxPluss/LexxHard-SensorControlBoard-Firmware/assets/2285892/974ea45a-aacf-42e9-a282-ab8d5a978b36)


[HWDEV-2025]: https://lexxpluss.atlassian.net/browse/HWDEV-2025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ