### PR TITLE
HWDEV-2001 Add key switch and resume switch handler

### DIFF
--- a/extra/boards/arm/lexxpluss_scb/lexxpluss_scb.dts
+++ b/extra/boards/arm/lexxpluss_scb/lexxpluss_scb.dts
@@ -240,6 +240,16 @@
 			gpios = <&gpioh 5 GPIO_ACTIVE_HIGH>;
 		};
 
+		/* Resume SW */
+		resume_sw_in: resume_sw_in {
+			compatible = "gpio-pin";
+			gpios = <&gpioi 14 GPIO_ACTIVE_HIGH>;
+		};
+		resume_led_out: resume_led_out {
+			compatible = "gpio-pin";
+			gpios = <&gpioi 9 GPIO_ACTIVE_HIGH>;
+		};
+
 		/* Safety */
 		wheel_en: wheel_en {
 			compatible = "gpio-pin";
@@ -349,10 +359,6 @@
 		};
 
 		/* Switch */
-		key_switch_center: key_switch_center {
-			compatible = "gpio-pin";
-			gpios = <&gpioi 9 GPIO_ACTIVE_HIGH>;
-		};
 		key_switch_left: key_switch_left {
 			compatible = "gpio-pin";
 			gpios = <&gpioi 10 GPIO_ACTIVE_HIGH>;
@@ -368,10 +374,6 @@
 		switch_stop: switch_stop {
 			compatible = "gpio-pin";
 			gpios = <&gpioi 13 GPIO_ACTIVE_HIGH>;
-		};
-		switch_resume: switch_resume {
-			compatible = "gpio-pin";
-			gpios = <&gpioi 14 GPIO_ACTIVE_HIGH>;
 		};
 		lift_up_switch: lift_up_switch {
 			compatible = "gpio-pin";

--- a/lexxpluss_apps/src/board_controller.cpp
+++ b/lexxpluss_apps/src/board_controller.cpp
@@ -254,8 +254,6 @@ public:
         }
         int now_right{gpio_pin_get_dt(&gpio_right_dev)};
 
-        //LOG_INF("now_left: %d, now_right: %d", now_left, now_right);
-
         if (prev_left != now_left || prev_right != now_right) {
             prev_left = now_left;
             prev_right = now_right;
@@ -1270,7 +1268,7 @@ private:
                         k_msgq_purge(&led_controller::msgq);
                 }
             } else if (ksw.is_maintenance()) {
-                LOG_INF("maintenance mode is selected by key switch\n");
+                LOG_DBG("maintenance mode is selected by key switch\n");
                 set_new_state(POWER_STATE::EMERGENCY);
             } else if (esw.is_asserted()) {
                 LOG_DBG("emergency switch asserted\n");
@@ -1299,7 +1297,7 @@ private:
                 LOG_DBG("DCDC failure\n");
                 set_new_state(POWER_STATE::STANDBY);
             } else if (ksw.is_maintenance()) {
-                LOG_INF("maintenance mode is selected by key switch\n");
+                LOG_DBG("maintenance mode is selected by key switch\n");
                 set_new_state(POWER_STATE::EMERGENCY);
             } else if (esw.is_asserted()) {
                 LOG_DBG("emergency switch asserted\n");
@@ -1308,7 +1306,7 @@ private:
                 LOG_DBG("receive emergency stop from ROS\n");
                 set_new_state(POWER_STATE::EMERGENCY);
             } else if (mbd.is_dead()) {
-                LOG_INF("mainboard is dead\n");
+                LOG_DBG("mainboard is dead\n");
                 set_new_state(POWER_STATE::STANDBY);
             } else if (mc.is_plugged()) {
                 LOG_DBG("plugged to manual charger\n");
@@ -1353,7 +1351,7 @@ private:
                         k_msgq_purge(&led_controller::msgq);
                 }
             } else if (!ksw.is_maintenance() && !esw.is_asserted() && !mbd.emergency_stop_from_ros()) {
-                LOG_INF("not emergency and heartbeat OK\n");
+                LOG_DBG("not emergency\n");
                 set_new_state(POWER_STATE::RESUME_WAIT);
             }
             break;
@@ -1373,7 +1371,7 @@ private:
                 LOG_DBG("DCDC failure\n");
                 set_new_state(POWER_STATE::EMERGENCY);
             } else if (ksw.is_maintenance()) {
-                LOG_INF("maintenance mode is selected by key switch\n");
+                LOG_DBG("maintenance mode is selected by key switch\n");
                 set_new_state(POWER_STATE::EMERGENCY);
             } else if (esw.is_asserted()) {
                 LOG_DBG("emergency switch asserted\n");
@@ -1382,7 +1380,7 @@ private:
                 LOG_DBG("receive emergency stop from ROS\n");
                 set_new_state(POWER_STATE::EMERGENCY);
             } else if (mbd.is_dead()) {
-                LOG_INF("mainboard is dead\n");
+                LOG_DBG("mainboard is dead\n");
                 set_new_state(POWER_STATE::EMERGENCY);
             } else if (rsw.get_state() == resume_switch::STATE::PUSHED) {
                 LOG_DBG("resume switch pushed\n");
@@ -1411,7 +1409,7 @@ private:
                 LOG_DBG("DCDC failure\n");
                 set_new_state(POWER_STATE::STANDBY);
             } else if (ksw.is_maintenance()) {
-                LOG_INF("maintenance mode is selected by key switch\n");
+                LOG_DBG("maintenance mode is selected by key switch\n");
                 set_new_state(POWER_STATE::EMERGENCY);
             } else if (esw.is_asserted()) {
                 LOG_DBG("emergency switch asserted\n");


### PR DESCRIPTION
Ref: [HWDEV-2001](https://lexxpluss.atlassian.net/browse/HWDEV-2001)

This PR is motivated to add handlers for back panel switches such as key switch and resume switch. This PR contains following modifications.

* Modify pin assignment 
  * `key_switch_center` is changed to `resume_led_out`
* Add resume switch handler
* Add key switch handler
* Add state transition rules which are triggered by key switch and resume switch

This PR is checked in real robot and worked correctly. 

[HWDEV-2001]: https://lexxpluss.atlassian.net/browse/HWDEV-2001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ