### PR TITLE
Hwdev 2080 handle bumper switch status reset

### DIFF
--- a/extra/boards/arm/lexxpluss_scb/lexxpluss_scb.dts
+++ b/extra/boards/arm/lexxpluss_scb/lexxpluss_scb.dts
@@ -259,6 +259,10 @@
 			compatible = "gpio-pin";
 			gpios = <&gpioi 7 GPIO_ACTIVE_HIGH>;
 		};
+		bp_reset: bp_reset {
+			compatible = "gpio-pin";
+			gpios = <&gpiof 4 GPIO_ACTIVE_HIGH>;
+		};
 		es_left: es_left {
 			compatible = "gpio-pin";
 			gpios = <&gpioi 4 GPIO_ACTIVE_HIGH>;

--- a/lexxpluss_apps/src/board_controller.cpp
+++ b/lexxpluss_apps/src/board_controller.cpp
@@ -291,7 +291,6 @@ private:
     static constexpr uint32_t COUNT{1};
 };
 
-#define BUMPER_SWITCH_HOLD_TIME_MS 1000
 class bumper_switch { // Variables Implemented
 public:
     void poll() {

--- a/lexxpluss_apps/src/board_controller.cpp
+++ b/lexxpluss_apps/src/board_controller.cpp
@@ -293,6 +293,14 @@ private:
 
 class bumper_switch { // Variables Implemented
 public:
+    void init() {
+        gpio_dt_spec gpio_dev = GET_GPIO(bp_reset);
+        if (!gpio_is_ready_dt(&gpio_dev)) {
+            LOG_ERR("gpio_is_ready_dt Failed\n");
+            return;
+        }
+        gpio_pin_set_dt(&gpio_dev, 0);
+    }
     void poll() {
         if(should_reset) {
             should_reset = false;
@@ -1088,6 +1096,7 @@ public:
         bmu.init();
         fan.init();
         mbd.init();
+        bsw.init();
 
         k_timer_init(&timer_poll_100ms, static_poll_100ms_callback, NULL);
         k_timer_user_data_set(&timer_poll_100ms, this);

--- a/lexxpluss_apps/src/main.cpp
+++ b/lexxpluss_apps/src/main.cpp
@@ -65,6 +65,9 @@ void init_gpio() {
     gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(ps_led_out), gpios);
     if (gpio_is_ready_dt(&gpio_dev))
         gpio_pin_configure_dt(&gpio_dev, GPIO_OUTPUT_LOW | GPIO_ACTIVE_HIGH);
+    gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(bp_reset), gpios);
+    if (gpio_is_ready_dt(&gpio_dev))
+        gpio_pin_configure_dt(&gpio_dev, GPIO_OUTPUT_LOW | GPIO_ACTIVE_HIGH);
     gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(v_autocharge), gpios);
     if (gpio_is_ready_dt(&gpio_dev))
         gpio_pin_configure_dt(&gpio_dev, GPIO_OUTPUT_LOW | GPIO_ACTIVE_HIGH);


### PR DESCRIPTION
Ref: [HWDEV-2080](https://lexxpluss.atlassian.net/browse/HWDEV-2080)

This PR is motivated to add handling logic to reset latched bumper switch status. This latching mechanism is achieved by RS Latch. So This PR contains following modifications 

* add `bs_reset` pin to dts file
* apply reset pulse to RESET pin of that latch when emergency switch is released
* remove bumper switch value holding by software
* add specifying callback interface to emergency_switch. This is feature is used to reset bumper switch latch when emergency switch is released.
* add `init` funciotn to bumper switch to reset `bs_reset` signal. 

This feature is designed to be run in next version hardware. So this PR is only checked by following.

* Calling logging function when creating reset pulse, And I found that expected logs ware shown when I released emergency switch.

[HWDEV-2080]: https://lexxpluss.atlassian.net/browse/HWDEV-2080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ