### PR TITLE
HWDEV-2093 add new pin assignments to dts file

### DIFF
--- a/extra/boards/arm/lexxpluss_scb/lexxpluss_scb.dts
+++ b/extra/boards/arm/lexxpluss_scb/lexxpluss_scb.dts
@@ -441,6 +441,38 @@
 			compatible = "gpio-pin";
 			gpios = <&gpioj 4 GPIO_ACTIVE_HIGH>;
 		};
+		spare_gpio_6: spare_gpio_6 {
+			compatible = "gpio-pin";
+			gpios = <&gpioa 8 GPIO_ACTIVE_HIGH>;
+		};
+		spare_gpio_7: spare_gpio_7 {
+			compatible = "gpio-pin";
+			gpios = <&gpioa 15 GPIO_ACTIVE_HIGH>;
+		};
+		spare_gpio_8: spare_gpio_8 {
+			compatible = "gpio-pin";
+			gpios = <&gpiob 2 GPIO_ACTIVE_HIGH>;
+		};
+		spare_gpio_9: spare_gpio_9 {
+			compatible = "gpio-pin";
+			gpios = <&gpiob 3 GPIO_ACTIVE_HIGH>;
+		};
+		spare_gpio_10: spare_gpio_10 {
+			compatible = "gpio-pin";
+			gpios = <&gpiob 4 GPIO_ACTIVE_HIGH>;
+		};
+		spare_gpio_11: spare_gpio_11 {
+			compatible = "gpio-pin";
+			gpios = <&gpioc 8 GPIO_ACTIVE_HIGH>;
+		};
+		spare_gpio_12: spare_gpio_12 {
+			compatible = "gpio-pin";
+			gpios = <&gpioc 9 GPIO_ACTIVE_HIGH>;
+		};
+		spare_gpio_13: spare_gpio_13 {
+			compatible = "gpio-pin";
+			gpios = <&gpioc 14 GPIO_ACTIVE_HIGH>;
+		};
 
 		/* etc */
 		adc_alert: adc_alert {

--- a/extra/boards/arm/lexxpluss_scb/lexxpluss_scb.dts
+++ b/extra/boards/arm/lexxpluss_scb/lexxpluss_scb.dts
@@ -167,6 +167,10 @@
 			compatible = "gpio-pin";
 			gpios = <&gpioh 9 GPIO_ACTIVE_HIGH>;
 		};
+		d_enc_ena: d_enc_ena {
+			compatible = "gpio-pin";
+			gpios = <&gpiod 14 GPIO_ACTIVE_HIGH>;
+		};
 
 		/* Power */
 		v24: v24 {
@@ -278,6 +282,38 @@
 		es_option_2: es_option_2 {
 			compatible = "gpio-pin";
 			gpios = <&gpioj 15 GPIO_ACTIVE_HIGH>;
+		};
+		eo_option_1: eo_option_1 {
+			compatible = "gpio-pin";
+			gpios = <&gpiog 2 GPIO_ACTIVE_HIGH>;
+		};
+		eo_option_2: eo_option_2 {
+			compatible = "gpio-pin";
+			gpios = <&gpiog 3 GPIO_ACTIVE_HIGH>;
+		};
+		safety_lidar_ossd1: safety_lidar_ossd1 {
+			compatible = "gpio-pin";
+			gpios = <&gpiof 5 GPIO_ACTIVE_HIGH>;
+		};
+		safety_lidar_ossd2: safety_lidar_ossd2 {
+			compatible = "gpio-pin";
+			gpios = <&gpiof 11 GPIO_ACTIVE_HIGH>;
+		};
+		safety_lidar_ossd3: safety_lidar_ossd3 {
+			compatible = "gpio-pin";
+			gpios = <&gpiof 13 GPIO_ACTIVE_HIGH>;
+		};
+		safety_lidar_ossd4: safety_lidar_ossd4 {
+			compatible = "gpio-pin";
+			gpios = <&gpiod 15 GPIO_ACTIVE_HIGH>;
+		};
+		safety_lidar_res_req1: safety_lidar_res_req1 {
+			compatible = "gpio-pin";
+			gpios = <&gpiog 10 GPIO_ACTIVE_HIGH>;
+		};
+		safety_lidar_res_req2: safety_lidar_res_req2 {
+			compatible = "gpio-pin";
+			gpios = <&gpiog 15 GPIO_ACTIVE_HIGH>;
 		};
 
 		/* BMU */


### PR DESCRIPTION
Ref: [HWDEV-2093](https://lexxpluss.atlassian.net/browse/HWDEV-2093)

This PR is motivated to add MUC pin assignments to dts files. These pin assignments are added by updating SCB schematics. But `Bumper_Sw_Reset` is not added in this PR. Becaus it will be added in https://github.com/LexxPluss/LexxHard-SensorControlBoard-Firmware/pull/28 .

[HWDEV-2093]: https://lexxpluss.atlassian.net/browse/HWDEV-2093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ