### PR TITLE
Hwdev 2079 improve handling emergency

### DIFF
--- a/lexxpluss_apps/src/actuator_controller.cpp
+++ b/lexxpluss_apps/src/actuator_controller.cpp
@@ -35,7 +35,7 @@
 #include <tuple>
 #include "actuator_controller.hpp"
 #include "adc_reader.hpp"
-#include "can_controller.hpp"
+#include "board_controller.hpp"
 #include "common.hpp"
 
 // for HW counter
@@ -632,7 +632,7 @@ public:
         while (true) {
             for (uint32_t i{0}; i < ACTUATOR_NUM; ++i)
                 act[i].poll();
-            bool is_emergency{can_controller::is_emergency()};  // -> board controller
+            bool is_emergency{board_controller::is_emergency()};  // -> board controller
             msg_control can2actuator;
             if (k_msgq_get(&msgq_control, &can2actuator, K_NO_WAIT) == 0 && !is_emergency)
                 handle_control(can2actuator);
@@ -671,7 +671,7 @@ public:
         pwm_trampoline_all(msg_control::DOWN, 100);
         bool stopped{wait_actuator_stop(30000, 100)};
         pwm_trampoline_all(msg_control::STOP);
-        if (!stopped || can_controller::is_emergency()) {
+        if (!stopped || board_controller::is_emergency()) {
             LOG_WRN("can not initialize location.");
             return -1;
         }
@@ -692,7 +692,7 @@ public:
             act[i].to_location(location[i], power[i]);
         bool stopped{wait_actuator_stop(30000, 100)};
         pwm_trampoline_all(msg_control::STOP);
-        if (!stopped || can_controller::is_emergency()) {
+        if (!stopped || board_controller::is_emergency()) {
             LOG_WRN("unable to move location.");
             return -1;
         }

--- a/lexxpluss_apps/src/board_controller.cpp
+++ b/lexxpluss_apps/src/board_controller.cpp
@@ -1145,6 +1145,17 @@ public:
     bool is_esw_asserted(){
         return esw.is_asserted();
     }
+    bool is_emergency() const {
+        bool rtn{false};
+        if (auto const state{static_cast<POWER_STATE>(board2ros.state)}; state != POWER_STATE::OFF) {
+            rtn = board2ros.emergency_switch_asserted ||
+               board2ros.bumper_switch_asserted ||
+               state == POWER_STATE::SUSPEND ||
+               state == POWER_STATE::RESUME_WAIT ||
+               mbd.emergency_stop_from_ros();
+        }
+        return rtn;
+    }
 private:
     static void static_poll_100ms_callback(struct k_timer *timer_id) {
         auto* instance = static_cast<state_controller*>(k_timer_user_data_get(timer_id));
@@ -1764,6 +1775,11 @@ void init()
 void run(void *p1, void *p2, void *p3)
 {
     impl.run();
+}
+
+bool is_emergency()
+{
+    return impl.is_emergency();
 }
 
 k_thread thread;

--- a/lexxpluss_apps/src/board_controller.cpp
+++ b/lexxpluss_apps/src/board_controller.cpp
@@ -1147,9 +1147,9 @@ public:
     }
     bool is_emergency() const {
         bool rtn{false};
-        if (auto const state{static_cast<POWER_STATE>(board2ros.state)}; state != POWER_STATE::OFF) {
-            rtn = board2ros.emergency_switch_asserted ||
-               board2ros.bumper_switch_asserted ||
+        if (state != POWER_STATE::OFF) {
+            rtn = esw.is_asserted() ||
+               bsw.is_asserted() ||
                state == POWER_STATE::SUSPEND ||
                state == POWER_STATE::RESUME_WAIT ||
                mbd.emergency_stop_from_ros();
@@ -1605,6 +1605,7 @@ private:
         board2ros.auto_charging_status = ac.is_docked();
         board2ros.shutdown_reason = static_cast<uint32_t>(shutdown_reason);
         board2ros.wait_shutdown_state = wait_shutdown;
+        board2ros.emergency_stop = is_emergency();
         board2ros.wheel_enable = wsw.is_enabled();
 
         bool v24{false}, v_peripheral{false}, v_wheel_motor_left{false}, v_wheel_motor_right{false};

--- a/lexxpluss_apps/src/board_controller.cpp
+++ b/lexxpluss_apps/src/board_controller.cpp
@@ -38,6 +38,7 @@
 #include "can_controller.hpp"
 #include "common.hpp"
 #include "led_controller.hpp"
+#include "power_state.hpp"
 
 namespace lexxhard::board_controller {
 
@@ -1170,19 +1171,6 @@ private:
         }
     }
 
-    enum class POWER_STATE {
-        OFF,
-        WAIT_SW,
-        POST,
-        STANDBY,
-        NORMAL,
-        AUTO_CHARGE,
-        MANUAL_CHARGE,
-        LOCKDOWN,
-        TIMEROFF,
-        SUSPEND,
-        RESUME_WAIT,
-    };
     void poll() {
         auto wheel_relay_control = [&](){
             bool wheel_poweroff{mbd.is_wheel_poweroff()};

--- a/lexxpluss_apps/src/board_controller.cpp
+++ b/lexxpluss_apps/src/board_controller.cpp
@@ -1180,7 +1180,7 @@ private:
         MANUAL_CHARGE,
         LOCKDOWN,
         TIMEROFF,
-        EMERGENCY,
+        SUSPEND,
         RESUME_WAIT,
     };
     void poll() {
@@ -1271,10 +1271,10 @@ private:
                 }
             } else if (ksw.is_maintenance()) {
                 LOG_DBG("maintenance mode is selected by key switch\n");
-                set_new_state(POWER_STATE::EMERGENCY);
+                set_new_state(POWER_STATE::SUSPEND);
             } else if (esw.is_asserted()) {
                 LOG_DBG("emergency switch asserted\n");
-                set_new_state(POWER_STATE::EMERGENCY);
+                set_new_state(POWER_STATE::SUSPEND);
             } else if (!esw.is_asserted() && !mbd.emergency_stop_from_ros() && mbd.is_ready()) {
                 LOG_DBG("not emergency and heartbeat OK\n");
                 set_new_state(POWER_STATE::NORMAL);
@@ -1300,13 +1300,13 @@ private:
                 set_new_state(POWER_STATE::STANDBY);
             } else if (ksw.is_maintenance()) {
                 LOG_DBG("maintenance mode is selected by key switch\n");
-                set_new_state(POWER_STATE::EMERGENCY);
+                set_new_state(POWER_STATE::SUSPEND);
             } else if (esw.is_asserted()) {
                 LOG_DBG("emergency switch asserted\n");
-                set_new_state(POWER_STATE::EMERGENCY);
+                set_new_state(POWER_STATE::SUSPEND);
             } else if (mbd.emergency_stop_from_ros()) {
                 LOG_DBG("receive emergency stop from ROS\n");
-                set_new_state(POWER_STATE::EMERGENCY);
+                set_new_state(POWER_STATE::SUSPEND);
             } else if (mbd.is_dead()) {
                 LOG_DBG("mainboard is dead\n");
                 set_new_state(POWER_STATE::STANDBY);
@@ -1320,7 +1320,7 @@ private:
                 }
             }
             break;
-        case POWER_STATE::EMERGENCY: {
+        case POWER_STATE::SUSPEND: {
             wheel_relay_control();
             auto psw_state{psw.get_state()};
             if (!dcdc.is_ok() || psw_state == power_switch::STATE::LONG_PUSHED) {
@@ -1362,28 +1362,28 @@ private:
             wheel_relay_control();
             if (psw.get_state() != power_switch::STATE::RELEASED) {
                 LOG_DBG("detect power switch\n");
-                set_new_state(POWER_STATE::EMERGENCY);
+                set_new_state(POWER_STATE::SUSPEND);
             } else if (mbd.power_off_from_ros()) {
                 LOG_DBG("receive power off from ROS\n");
-                set_new_state(POWER_STATE::EMERGENCY);
+                set_new_state(POWER_STATE::SUSPEND);
             } else if (!bmu.is_ok()) {
                 LOG_DBG("BMU failure\n");
-                set_new_state(POWER_STATE::EMERGENCY);
+                set_new_state(POWER_STATE::SUSPEND);
             } else if (!dcdc.is_ok()) {
                 LOG_DBG("DCDC failure\n");
-                set_new_state(POWER_STATE::EMERGENCY);
+                set_new_state(POWER_STATE::SUSPEND);
             } else if (ksw.is_maintenance()) {
                 LOG_DBG("maintenance mode is selected by key switch\n");
-                set_new_state(POWER_STATE::EMERGENCY);
+                set_new_state(POWER_STATE::SUSPEND);
             } else if (esw.is_asserted()) {
                 LOG_DBG("emergency switch asserted\n");
-                set_new_state(POWER_STATE::EMERGENCY);
+                set_new_state(POWER_STATE::SUSPEND);
             } else if (mbd.emergency_stop_from_ros()) {
                 LOG_DBG("receive emergency stop from ROS\n");
-                set_new_state(POWER_STATE::EMERGENCY);
+                set_new_state(POWER_STATE::SUSPEND);
             } else if (mbd.is_dead()) {
                 LOG_DBG("mainboard is dead\n");
-                set_new_state(POWER_STATE::EMERGENCY);
+                set_new_state(POWER_STATE::SUSPEND);
             } else if (rsw.get_state() == resume_switch::STATE::PUSHED) {
                 LOG_DBG("resume switch pushed\n");
                 if (mbd.is_ready()) {
@@ -1412,13 +1412,13 @@ private:
                 set_new_state(POWER_STATE::STANDBY);
             } else if (ksw.is_maintenance()) {
                 LOG_DBG("maintenance mode is selected by key switch\n");
-                set_new_state(POWER_STATE::EMERGENCY);
+                set_new_state(POWER_STATE::SUSPEND);
             } else if (esw.is_asserted()) {
                 LOG_DBG("emergency switch asserted\n");
-                set_new_state(POWER_STATE::EMERGENCY);
+                set_new_state(POWER_STATE::SUSPEND);
             } else if (mbd.emergency_stop_from_ros()) {
                 LOG_DBG("receive emergency stop from ROS\n");
-                set_new_state(POWER_STATE::EMERGENCY);
+                set_new_state(POWER_STATE::SUSPEND);
             } else if (mbd.is_dead()) {
                 LOG_DBG("main board or ROS dead\n");
                 set_new_state(POWER_STATE::STANDBY);
@@ -1539,8 +1539,8 @@ private:
             k_timer_start(&charge_guard_timeout, K_MSEC(10000), K_NO_WAIT); // charge_guard_asserted = false after 10sec
             break;
 
-        case POWER_STATE::EMERGENCY:
-            LOG_INF("enter EMERGENCY\n");
+        case POWER_STATE::SUSPEND:
+            LOG_INF("enter SUSPEND\n");
             psw.set_led(true);
             wsw.set_disable(true);
             gpio_dev = GET_GPIO(v_wheel);

--- a/lexxpluss_apps/src/board_controller.hpp
+++ b/lexxpluss_apps/src/board_controller.hpp
@@ -46,6 +46,7 @@ struct msg_rcv_pb {
 
 void init();
 void run(void *p1, void *p2, void *p3);
+bool is_emergency();
 extern k_thread thread;
 extern k_msgq msgq_can_bmu_pb;
 extern k_msgq msgq_board_pb_rx, msgq_board_pb_tx;

--- a/lexxpluss_apps/src/can_controller.cpp
+++ b/lexxpluss_apps/src/can_controller.cpp
@@ -32,6 +32,7 @@
 #include "can_controller.hpp"
 #include "board_controller.hpp"
 #include "led_controller.hpp"
+#include "power_state.hpp"
 
 namespace lexxhard::can_controller {
 
@@ -73,7 +74,7 @@ public:
             }
 
             // if the board_controller state is 0 (OFF), prev_cycle_ros is reset
-            if (board2ros.state == 0) {
+            if (static_cast<POWER_STATE>(board2ros.state) == POWER_STATE::OFF) {
                 prev_cycle_ros = 0;
                 prev_cycle_send = 0;
                 ros2board.emergency_stop = true;
@@ -102,7 +103,7 @@ public:
     }
     bool is_emergency() const {
         bool rtn{false};
-        if (board2ros.state != 0) {
+        if (static_cast<POWER_STATE>(board2ros.state) != POWER_STATE::OFF) {
             rtn = board2ros.emergency_switch_asserted ||
                board2ros.bumper_switch_asserted ||
                ros2board.emergency_stop;

--- a/lexxpluss_apps/src/can_controller.cpp
+++ b/lexxpluss_apps/src/can_controller.cpp
@@ -101,17 +101,6 @@ public:
     bool get_bumper_switch() const {
 	return board2ros.bumper_switch_asserted;
     }
-    bool is_emergency() const {
-        bool rtn{false};
-        if (auto const state{static_cast<POWER_STATE>(board2ros.state)}; state != POWER_STATE::OFF) {
-            rtn = board2ros.emergency_switch_asserted ||
-               board2ros.bumper_switch_asserted ||
-               state == POWER_STATE::SUSPEND ||
-               state == POWER_STATE::RESUME_WAIT ||
-               ros2board.emergency_stop;
-        }
-        return rtn;
-    }
     void brd_emgoff() {
         ros2board.emergency_stop = false;
         heartbeat_timeout = false;
@@ -212,11 +201,6 @@ bool get_emergency_switch()
 bool get_bumper_switch()
 {
     return impl.get_bumper_switch();
-}
-
-bool is_emergency()
-{
-    return impl.is_emergency();
 }
 
 k_thread thread;

--- a/lexxpluss_apps/src/can_controller.cpp
+++ b/lexxpluss_apps/src/can_controller.cpp
@@ -103,9 +103,11 @@ public:
     }
     bool is_emergency() const {
         bool rtn{false};
-        if (static_cast<POWER_STATE>(board2ros.state) != POWER_STATE::OFF) {
+        if (auto const state{static_cast<POWER_STATE>(board2ros.state)}; state != POWER_STATE::OFF) {
             rtn = board2ros.emergency_switch_asserted ||
                board2ros.bumper_switch_asserted ||
+               state == POWER_STATE::SUSPEND ||
+               state == POWER_STATE::RESUME_WAIT ||
                ros2board.emergency_stop;
         }
         return rtn;

--- a/lexxpluss_apps/src/can_controller.hpp
+++ b/lexxpluss_apps/src/can_controller.hpp
@@ -70,7 +70,6 @@ void init();
 void run(void *p1, void *p2, void *p3);
 bool get_emergency_switch();
 bool get_bumper_switch();
-bool is_emergency();
 extern k_thread thread;
 extern k_msgq /*msgq_bmu,*/ msgq_board, msgq_control;
 

--- a/lexxpluss_apps/src/can_controller.hpp
+++ b/lexxpluss_apps/src/can_controller.hpp
@@ -60,6 +60,7 @@ struct msg_board {
     bool c_act_pgood, l_act_pgood, r_act_pgood;
     bool wheel_enable;
     bool charge_temperature_good;
+    bool emergency_stop;
 } __attribute__((aligned(4)));
 
 struct msg_control {

--- a/lexxpluss_apps/src/led_controller.cpp
+++ b/lexxpluss_apps/src/led_controller.cpp
@@ -31,7 +31,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include "bmu_controller.hpp"
-#include "can_controller.hpp"
+#include "board_controller.hpp"
 #include "led_controller.hpp"
 
 namespace lexxhard::led_controller {
@@ -152,7 +152,7 @@ private:
     void update() {
         std::copy(&pixeldata[LED_LEFT][0],  &pixeldata[LED_LEFT][PIXELS_BACK],  &pixeldata_back[LED_LEFT][0]);
         std::copy(&pixeldata[LED_RIGHT][0], &pixeldata[LED_RIGHT][PIXELS_BACK], &pixeldata_back[LED_RIGHT][0]);
-        if (can_controller::is_emergency()) {
+        if (board_controller::is_emergency()) {
             static uint32_t blink_counter{0};
             ++blink_counter;
             if (blink_counter < 20) {

--- a/lexxpluss_apps/src/power_state.hpp
+++ b/lexxpluss_apps/src/power_state.hpp
@@ -1,0 +1,13 @@
+enum class POWER_STATE {
+    OFF,
+    WAIT_SW,
+    POST,
+    STANDBY,
+    NORMAL,
+    AUTO_CHARGE,
+    MANUAL_CHARGE,
+    LOCKDOWN,
+    TIMEROFF,
+    SUSPEND,
+    RESUME_WAIT,
+};

--- a/lexxpluss_apps/src/zcan_board.hpp
+++ b/lexxpluss_apps/src/zcan_board.hpp
@@ -81,6 +81,9 @@ public:
             if (message.wait_shutdown_state) {
                 packedData[0] |= 0b00001000;
             }
+            if (message.emergency_stop) {
+                packedData[0] |= 0b00000100;
+            }
 
             if (message.auto_charging_status){
                 packedData[1] = 0x01;


### PR DESCRIPTION
Ref: [HWDEV-2082](https://lexxpluss.atlassian.net/browse/HWDEV-2082)

This PR is motivated to improve handling emergency status. In the current implementation, there are following undesirable features.

* `is_emergency` function is located int can_controller
* there is no way to notify emergency status to application layer
* Use state as integer value instead of enum
* The name of `EMERGENCY` which is one of POWER_STATE is confusion. Because emergency is not controlled by states. This means that  `is_emergency` may return true in other states.

So this PR fixed above undesirable features by followings.

* move `is_emergency` from can_controller to board_controller
* add `emergency` field to can message to express the emergency status
* extract POWER_STATE into new file whose name is `power_state.hpp`
* change `EMERGENCY` to `SUSPEND`

After applying above modifications, we could found the following candump logs. The 2nd bit of the first byte of message means emergency. This means that emergency occurs when  the lower first bytes is 4 .

```
  can1  20C   [6]  00 00 00 FF 00 19
  can1  20C   [6]  00 00 00 FF 00 18
  can1  20C   [6]  34 00 00 FF 00 19
  can1  20C   [6]  34 00 00 FF 00 19
  can1  20C   [6]  34 00 00 FF 00 18
  can1  20C   [6]  34 00 00 FF 00 16
  can1  20C   [6]  34 00 00 FF 00 18
  can1  20C   [6]  34 00 00 FF 00 18
  can1  20C   [6]  34 00 00 FF 00 1B
  can1  20C   [6]  34 00 00 FF 00 18
  can1  20C   [6]  34 00 00 FF 00 18
  can1  20C   [6]  34 00 00 FF 00 18
  can1  20C   [6]  34 00 00 FF 00 19
  can1  20C   [6]  04 00 00 FF 00 19
  can1  20C   [6]  04 00 00 FF 00 18
  can1  20C   [6]  04 00 00 FF 00 19
  can1  20C   [6]  04 00 00 FF 00 19
  can1  20C   [6]  04 00 00 FF 00 18
```

[HWDEV-2082]: https://lexxpluss.atlassian.net/browse/HWDEV-2082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ