### PR TITLE
HWDEV-2158 add handling resume switch led

### DIFF
--- a/lexxpluss_apps/src/board_controller.cpp
+++ b/lexxpluss_apps/src/board_controller.cpp
@@ -1522,6 +1522,9 @@ private:
             k_timer_stop(&current_check_timeout);
             ac.force_stop();
             break;
+        case POWER_STATE::RESUME_WAIT:
+            rsw.set_led(false);
+            break;
         default:
             break;
         }
@@ -1533,6 +1536,7 @@ private:
             LOG_INF("enter OFF\n");
             poweron_by_switch = false;
             psw.set_led(false);
+            rsw.set_led(false);
             dcdc.set_enable(false);
 
             // Set LED OFF
@@ -1607,6 +1611,7 @@ private:
             break;
         case POWER_STATE::RESUME_WAIT:
             LOG_INF("enter RESUME_WAIT\n");
+            rsw.set_led(true);
             break;
         case POWER_STATE::AUTO_CHARGE:
             LOG_INF("enter AUTO_CHARGE\n");

--- a/lexxpluss_apps/src/main.cpp
+++ b/lexxpluss_apps/src/main.cpp
@@ -65,6 +65,9 @@ void init_gpio() {
     gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(ps_led_out), gpios);
     if (gpio_is_ready_dt(&gpio_dev))
         gpio_pin_configure_dt(&gpio_dev, GPIO_OUTPUT_LOW | GPIO_ACTIVE_HIGH);
+    gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(resume_led_out), gpios);
+    if (gpio_is_ready_dt(&gpio_dev))
+        gpio_pin_configure_dt(&gpio_dev, GPIO_OUTPUT_LOW | GPIO_ACTIVE_HIGH);
     gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(bp_reset), gpios);
     if (gpio_is_ready_dt(&gpio_dev))
         gpio_pin_configure_dt(&gpio_dev, GPIO_OUTPUT_LOW | GPIO_ACTIVE_HIGH);
@@ -104,6 +107,9 @@ void init_gpio() {
     
     // Input
     gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(ps_sw_in), gpios);
+    if (gpio_is_ready_dt(&gpio_dev))
+        gpio_pin_configure_dt(&gpio_dev, GPIO_INPUT | GPIO_ACTIVE_HIGH);
+    gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(resume_sw_in), gpios);
     if (gpio_is_ready_dt(&gpio_dev))
         gpio_pin_configure_dt(&gpio_dev, GPIO_INPUT | GPIO_ACTIVE_HIGH);
     gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(bp_left), gpios);


### PR DESCRIPTION
Ref [HWDEV-2158](https://lexxpluss.atlassian.net/browse/HWDEV-2158)

This PR is motivated to add resume led handling. This PR contains followings.

* Clear LED when exiting RESUME_WAIT state
* Clear LED when entering OFF state. 
* Set LED when entering RESUME_WAIT state
* Configure GPIO pins

[HWDEV-2158]: https://lexxpluss.atlassian.net/browse/HWDEV-2158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ