### PR TITLE
Hwdev 2086 add gpio support

### DIFF
--- a/lexxpluss_apps/src/gpio_controller.cpp
+++ b/lexxpluss_apps/src/gpio_controller.cpp
@@ -90,8 +90,8 @@ public:
         constexpr auto get_status_char = [](bool status) {
             return status ? 'H' : 'L';
         };
-        shell_print(shell, "INPUT 0:%c, 1:%c, 2:%c, 3:%c", get_status_char(gpio_in_status[0]), get_status_char(gpio_in_status[1]), get_status_char(gpio_in_status[2]), get_status_char(gpio_in_status[3]));
-        shell_print(shell, "OUTPUT 0:%c, 1:%c, 2:%c, 3:%c", get_status_char(gpio_out_status[0]), get_status_char(gpio_out_status[1]), get_status_char(gpio_out_status[2]), get_status_char(gpio_out_status[3]));
+        shell_print(shell, "INPUT  0:%c 1:%c 2:%c 3:%c", get_status_char(gpio_in_status[0]), get_status_char(gpio_in_status[1]), get_status_char(gpio_in_status[2]), get_status_char(gpio_in_status[3]));
+        shell_print(shell, "OUTPUT 0:%c 1:%c 2:%c 3:%c", get_status_char(gpio_out_status[0]), get_status_char(gpio_out_status[1]), get_status_char(gpio_out_status[2]), get_status_char(gpio_out_status[3]));
     }
 
     void set_gpio_out(size_t n, bool value) {

--- a/lexxpluss_apps/src/gpio_controller.cpp
+++ b/lexxpluss_apps/src/gpio_controller.cpp
@@ -44,7 +44,7 @@ char __aligned(4) msgq_control_buffer[8 * sizeof (msg_control)];
 
 class gpio_controller_impl {
 public:
-    constexpr int32_t POLL_INTERVAL_MS = 100;
+    static constexpr int32_t POLL_INTERVAL_MS = 100;
 
     int init() {
         k_msgq_init(&msgq, msgq_buffer, sizeof (msg), 8);

--- a/lexxpluss_apps/src/gpio_controller.cpp
+++ b/lexxpluss_apps/src/gpio_controller.cpp
@@ -1,0 +1,235 @@
+/*
+ * Copyright (c) 2024, LexxPluss Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+
+#include <zephyr/kernel.h>
+#include <array>
+#include <cstdlib>
+#include <optional>
+#include <zephyr/device.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/shell/shell.h>
+#include <zephyr/drivers/gpio.h>
+#include "gpio_controller.hpp"
+#include "common.hpp"
+
+namespace lexxhard::gpio_controller { 
+
+LOG_MODULE_REGISTER(gpio);
+
+char __aligned(4) msgq_buffer[8 * sizeof (msg)];
+char __aligned(4) msgq_control_buffer[8 * sizeof (msg_control)];
+
+class gpio_controller_impl {
+public:
+    constexpr int32_t POLL_INTERVAL_MS = 100;
+
+    int init() {
+        k_msgq_init(&msgq, msgq_buffer, sizeof (msg), 8);
+        k_msgq_init(&msgq_control, msgq_control_buffer, sizeof (msg_control), 8);
+
+        if (!check_devices()) {
+            LOG_ERR("gpio_is_ready_dt Failed");
+            return -1;
+        }
+
+        if(!update_status()) {
+            LOG_ERR("Failed to update status");
+            return -1;
+        }
+        return 0;
+    }
+
+    void run() {
+        if (!check_devices()) {
+            LOG_ERR("gpio_is_ready_dt Failed");
+            return;
+        }
+
+        while (true) {
+            if(!update_status()) {
+                LOG_ERR("Failed to update status");
+                return;
+            }
+
+            if (msg_control msg_control; k_msgq_get(&msgq_control, &msg_control, K_NO_WAIT) == 0) {
+                handle_msg_control(msg_control);
+            }
+
+            msg msg = create_msg();
+            while (k_msgq_put(&msgq, &msg, K_NO_WAIT) != 0) {
+                k_msgq_purge(&msgq);
+            }
+            k_msleep(POLL_INTERVAL_MS);
+        }
+    }
+
+    void info(const shell *shell) const {
+        constexpr auto get_status_char = [](bool status) {
+            return status ? 'H' : 'L';
+        };
+        shell_print(shell, "INPUT 0:%c, 1:%c, 2:%c, 3:%c", get_status_char(gpio_in_status[0]), get_status_char(gpio_in_status[1]), get_status_char(gpio_in_status[2]), get_status_char(gpio_in_status[3]));
+        shell_print(shell, "OUTPUT 0:%c, 1:%c, 2:%c, 3:%c", get_status_char(gpio_out_status[0]), get_status_char(gpio_out_status[1]), get_status_char(gpio_out_status[2]), get_status_char(gpio_out_status[3]));
+    }
+
+    void set_gpio_out(size_t n, bool value) {
+        if(gpio_out_devs.size() <= n) {
+            LOG_ERR("N is out of range");
+            return;
+        }
+
+        const gpio_dt_spec *gpio_dev = &gpio_out_devs[n];
+        set_gpio(gpio_dev, value);
+    }
+
+private:
+    void set_gpio(const gpio_dt_spec *gpio_dev, bool value) {
+        if (!gpio_is_ready_dt(gpio_dev)) {
+            LOG_ERR("gpio_is_ready_dt Failed");
+            return;
+        }
+        gpio_pin_set_dt(gpio_dev, value);
+    }
+
+    std::optional<bool> get_gpio(const gpio_dt_spec *gpio_dev) {
+        if (!gpio_is_ready_dt(gpio_dev)) {
+            LOG_ERR("gpio_is_ready_dt Failed");
+            return std::nullopt;
+        }
+        return gpio_pin_get_dt(gpio_dev);
+    }
+
+    bool update_status() {
+        for(size_t i = 0; i < 4; i++) {
+            auto status = get_gpio(&gpio_out_devs[i]);
+            if(!status.has_value()) {
+                return false;
+            }
+            gpio_out_status[i] = status.value();
+
+            status = get_gpio(&gpio_in_devs[i]);
+            if(!status.has_value()) {
+                return false;
+            }
+            gpio_in_status[i] = status.value();
+        }
+
+        return true;
+    }
+
+    void handle_msg_control(const msg_control &msg) {
+        set_gpio_out(0, msg.ros_gpio_out_0);
+        set_gpio_out(1, msg.ros_gpio_out_1);
+        set_gpio_out(2, msg.ros_gpio_out_2);
+        set_gpio_out(3, msg.ros_gpio_out_3);
+    }
+
+    msg create_msg() const {
+        return msg{
+            .gpio_in_0 = gpio_in_status[0],
+            .gpio_in_1 = gpio_in_status[1],
+            .gpio_in_2 = gpio_in_status[2],
+            .gpio_in_3 = gpio_in_status[3],
+        };
+    }
+
+    bool check_devices(){
+        for(size_t i = 0; i < 4; i++) {
+            if (!gpio_is_ready_dt(&gpio_out_devs[i])) {
+                return false;
+            }
+        }
+
+        for(size_t i = 0; i < 4; i++) {
+            if (!gpio_is_ready_dt(&gpio_in_devs[i])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    const std::array<const gpio_dt_spec, 4> gpio_out_devs{{
+        GET_GPIO(spare_gpio_6),
+        GET_GPIO(spare_gpio_7),
+        GET_GPIO(spare_gpio_8),
+        GET_GPIO(spare_gpio_9)
+    }};
+    std::array<bool, 4> gpio_out_status;
+    const std::array<const gpio_dt_spec, 4> gpio_in_devs{{
+        GET_GPIO(spare_gpio_10),
+        GET_GPIO(spare_gpio_11),
+        GET_GPIO(spare_gpio_12),
+        GET_GPIO(spare_gpio_13)
+    }};
+    std::array<bool, 4> gpio_in_status;
+} impl;
+
+int info(const shell *shell, size_t argc, char **argv)
+{
+    impl.info(shell);
+    return 0;
+}
+
+int set(const shell *shell, size_t argc, char **argv)
+{
+    shell_print(shell, "[notice] parameter order [index] [status (0 or 1)]");
+    if (argc != 3) {
+        shell_error(shell, "Usage: %s %s <index> <status>", argv[-1], argv[0]);
+        return 1;
+    }
+
+    auto const ind = atoi(argv[1]);
+    auto const status = atoi(argv[2]);
+    if(status != 0 && status != 1) {
+        shell_error(shell, "status must be 0 or 1");
+        return 1;
+    }
+
+    impl.set_gpio_out(ind, status);
+    return 0;
+}
+
+SHELL_STATIC_SUBCMD_SET_CREATE(sub_gpio,
+    SHELL_CMD(info, NULL, "GPIO information", info),
+    SHELL_CMD(set, NULL, "GPIO set command", set),
+    SHELL_SUBCMD_SET_END
+);
+SHELL_CMD_REGISTER(gpio, &sub_gpio, "GPIO commands", NULL);
+
+void init()
+{
+    impl.init();
+}
+
+void run(void *p1, void *p2, void *p3)
+{
+    impl.run();
+}
+
+k_thread thread;
+k_msgq msgq, msgq_control;
+
+}

--- a/lexxpluss_apps/src/gpio_controller.hpp
+++ b/lexxpluss_apps/src/gpio_controller.hpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2024, LexxPluss Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+#pragma once
+
+#include <zephyr/kernel.h>
+
+namespace lexxhard::gpio_controller {
+
+#define GPIO_CAN_DATA_LENGTH 1
+
+struct msg {
+    bool gpio_in_0: 1;
+    bool gpio_in_1: 1;
+    bool gpio_in_2: 1;
+    bool gpio_in_3: 1;
+} __attribute__((aligned(4)));
+
+struct msg_control {
+    bool ros_gpio_out_0: 1;
+    bool ros_gpio_out_1: 1;
+    bool ros_gpio_out_2: 1;
+    bool ros_gpio_out_3: 1;
+} __attribute__((aligned(4)));
+
+void init();
+void run(void *p1, void *p2, void *p3);
+extern k_thread thread;
+extern k_msgq msgq, msgq_control;
+}
+
+// vim: set expandtab shiftwidth=4:

--- a/lexxpluss_apps/src/main.cpp
+++ b/lexxpluss_apps/src/main.cpp
@@ -37,6 +37,7 @@
 #include "zcan_main.hpp"
 #include "runaway_detector.hpp"
 #include "uss_controller.hpp"
+#include "gpio_controller.hpp"
 
 namespace {
 
@@ -51,6 +52,7 @@ K_THREAD_STACK_DEFINE(led_controller_stack, 2048);
 K_THREAD_STACK_DEFINE(pgv_controller_stack, 2048);
 K_THREAD_STACK_DEFINE(runaway_detector_stack, 2048);
 K_THREAD_STACK_DEFINE(uss_controller_stack, 2048);
+K_THREAD_STACK_DEFINE(gpio_controller_stack, 2048);
 K_THREAD_STACK_DEFINE(zcan_main_stack, 2048);
 
 #define RUN(name, prio) \
@@ -259,6 +261,7 @@ int main()
     lexxhard::zcan_main::init();
     lexxhard::runaway_detector::init();
     lexxhard::uss_controller::init();
+    lexxhard::gpio_controller::init();
 
     RUN(actuator_controller, 2);
     RUN(adc_reader, 2);
@@ -270,6 +273,7 @@ int main()
     RUN(led_controller, 1);
     RUN(pgv_controller, 1);
     RUN(uss_controller, 2);
+    RUN(gpio_controller, 2);
     RUN(runaway_detector, 4);
     RUN(zcan_main, 5); // zcan_main thread must be started at last.
 

--- a/lexxpluss_apps/src/main.cpp
+++ b/lexxpluss_apps/src/main.cpp
@@ -104,6 +104,19 @@ void init_gpio() {
     gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(ipc_power_sw_fp), gpios);
     if (gpio_is_ready_dt(&gpio_dev))
         gpio_pin_configure_dt(&gpio_dev, GPIO_OUTPUT_LOW | GPIO_ACTIVE_HIGH);
+    gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(spare_gpio_6), gpios);
+    if (gpio_is_ready_dt(&gpio_dev))
+        gpio_pin_configure_dt(&gpio_dev, GPIO_OUTPUT_LOW | GPIO_ACTIVE_HIGH);
+    gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(spare_gpio_7), gpios);
+    if (gpio_is_ready_dt(&gpio_dev))
+        gpio_pin_configure_dt(&gpio_dev, GPIO_OUTPUT_LOW | GPIO_ACTIVE_HIGH);
+    gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(spare_gpio_8), gpios);
+    if (gpio_is_ready_dt(&gpio_dev))
+        gpio_pin_configure_dt(&gpio_dev, GPIO_OUTPUT_LOW | GPIO_ACTIVE_HIGH);
+    gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(spare_gpio_9), gpios);
+    if (gpio_is_ready_dt(&gpio_dev))
+        gpio_pin_configure_dt(&gpio_dev, GPIO_OUTPUT_LOW | GPIO_ACTIVE_HIGH);
+
     
     // Input
     gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(ps_sw_in), gpios);
@@ -145,7 +158,19 @@ void init_gpio() {
     gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(pgood_wheel_motor_right), gpios);
     if (gpio_is_ready_dt(&gpio_dev))
         gpio_pin_configure_dt(&gpio_dev, GPIO_INPUT | GPIO_PULL_UP | GPIO_ACTIVE_HIGH);
-    
+    gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(spare_gpio_10), gpios);
+    if (gpio_is_ready_dt(&gpio_dev))
+        gpio_pin_configure_dt(&gpio_dev, GPIO_INPUT | GPIO_PULL_UP | GPIO_ACTIVE_HIGH);
+    gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(spare_gpio_11), gpios);
+    if (gpio_is_ready_dt(&gpio_dev))
+        gpio_pin_configure_dt(&gpio_dev, GPIO_INPUT | GPIO_PULL_UP | GPIO_ACTIVE_HIGH);
+    gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(spare_gpio_12), gpios);
+    if (gpio_is_ready_dt(&gpio_dev))
+        gpio_pin_configure_dt(&gpio_dev, GPIO_INPUT | GPIO_PULL_UP | GPIO_ACTIVE_HIGH);
+    gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(spare_gpio_13), gpios);
+    if (gpio_is_ready_dt(&gpio_dev))
+        gpio_pin_configure_dt(&gpio_dev, GPIO_INPUT | GPIO_PULL_UP | GPIO_ACTIVE_HIGH);
+
     // LED
     gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(dbg_led1), gpios);
     if (gpio_is_ready_dt(&gpio_dev))

--- a/lexxpluss_apps/src/zcan_gpio.hpp
+++ b/lexxpluss_apps/src/zcan_gpio.hpp
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2023, LexxPlgpio Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <zephyr/kernel.h>
+#include <zephyr/drivers/can.h>
+#include <zephyr/logging/log.h>
+#include "gpio_controller.hpp"
+
+#define CAN_ID_GPIO_OUT 0x211
+#define CAN_ID_GPIO_IN 0x212
+#define CAN_DATA_LENGTH_GPIO_OUT 1
+#define CAN_DATA_LENGTH_GPIO_IN 1
+
+namespace lexxhard::zcan_gpio {
+
+LOG_MODULE_REGISTER(zcan_gpio);
+
+char __aligned(4) msgq_led_buffer[8 * sizeof (struct can_frame)];
+
+CAN_MSGQ_DEFINE(msgq_can_gpio, 16);
+
+class zcan_gpio {
+public:
+    void init() {
+        dev = DEVICE_DT_GET(DT_NODELABEL(can2));
+        if (!device_is_ready(dev)){
+            LOG_ERR("CAN_2 is not ready");
+            return;
+        }
+
+        static const can_filter filter{
+            .id{CAN_ID_GPIO_OUT},
+            .mask{0x7ff}
+        };
+        can_add_rx_filter_msgq(dev, &msgq_can_gpio, &filter);
+    }
+    void poll() {
+        gpio_controller::msg message;
+        while (k_msgq_get(&gpio_controller::msgq, &message, K_NO_WAIT) == 0) {
+            uint8_t packedData[CAN_DATA_LENGTH_GPIO_IN] {
+                pack_gpio_input_status(message)
+            };
+
+            // set data to CAN frame
+            can_frame frame{
+                .id = CAN_ID_GPIO_IN,
+                .dlc = CAN_DATA_LENGTH_GPIO_IN,
+                .data = {0}
+            };
+
+            // copy packedData to CAN frame data
+            memcpy(frame.data, packedData, CAN_DATA_LENGTH_GPIO_IN);
+
+            can_send(dev, &frame, K_MSEC(100), nullptr, nullptr);
+        }
+
+        struct can_frame frame;
+        while (k_msgq_get(&msgq_can_gpio, &frame, K_NO_WAIT) == 0) {
+            if (frame.id != CAN_ID_GPIO_OUT || frame.dlc != CAN_DATA_LENGTH_GPIO_OUT) {
+                LOG_INF("Unknown CAN frame received: %x %x", frame.id, frame.dlc);
+                continue;
+            }
+
+            const gpio_controller::msg_control msg{unpack_gpio_output_status(frame)};
+            while (k_msgq_put(&gpio_controller::msgq_control, &msg, K_NO_WAIT) != 0)
+                k_msgq_purge(&gpio_controller::msgq_control);
+        }
+    }
+private:
+    uint8_t pack_gpio_input_status(gpio_controller::msg const &message) const {
+        uint8_t ret{0};
+        ret |= static_cast<uint8_t>(message.gpio_in_0) << 7;
+        ret |= static_cast<uint8_t>(message.gpio_in_1) << 6;
+        ret |= static_cast<uint8_t>(message.gpio_in_2) << 5;
+        ret |= static_cast<uint8_t>(message.gpio_in_3) << 4;
+
+        return ret;
+    }
+
+    gpio_controller::msg_control unpack_gpio_output_status(can_frame const &frame) const {
+        gpio_controller::msg_control ret;
+        ret.ros_gpio_out_0 = static_cast<bool>((frame.data[0] & 0b10000000) >> 7);
+        ret.ros_gpio_out_1 = static_cast<bool>((frame.data[0] & 0b01000000) >> 6);
+        ret.ros_gpio_out_2 = static_cast<bool>((frame.data[0] & 0b00100000) >> 5);
+        ret.ros_gpio_out_3 = static_cast<bool>((frame.data[0] & 0b00010000) >> 4);
+
+        return ret;
+    }
+
+    const device *dev{nullptr};
+};
+
+}

--- a/lexxpluss_apps/src/zcan_main.cpp
+++ b/lexxpluss_apps/src/zcan_main.cpp
@@ -32,6 +32,7 @@
 #include "zcan_pgv.hpp"
 #include "zcan_uss.hpp"
 #include "zcan_dfu.hpp"
+#include "zcan_gpio.hpp"
 #include "zcan_main.hpp"
 
 namespace lexxhard::zcan_main {
@@ -60,6 +61,7 @@ public:
         led.init();
         pgv.init();
         uss.init();
+        gpio.init();
         return 0;
     }
     void run() {
@@ -72,6 +74,7 @@ public:
             led.poll();
             pgv.poll();
             uss.poll();
+            gpio.poll();
             k_usleep(1);
         }
     }
@@ -85,6 +88,7 @@ private:
     lexxhard::zcan_led::zcan_led led;
     lexxhard::zcan_pgv::zcan_pgv pgv;
     lexxhard::zcan_uss::zcan_uss uss;
+    lexxhard::zcan_gpio::zcan_gpio gpio;
 } impl;
 
 void init()


### PR DESCRIPTION
ref: [HWDEV-2086](https://lexxpluss.atlassian.net/browse/HWDEV-2086)

This PR is motivated to add a feature of handling GPIO Port. To avhieve it, this PR contains following modifications.

* Add gpio_controller to handle input and output GPIO pins
* Add zcan_gpio to convert can message to internal message and  vice versa.

The following results are from gpio command in zephyr shell.

The gpio command has two subcommands. The one is `info` and the other is set. 
```
uart:~$ gpio
gpio - GPIO commands
Subcommands:
  info  : GPIO information
  set   : GPIO set command
```

The `info` subcommand shows the status of GPIO pins. In the following, `H` means high level and `L` means low level.
```
uart:~$ gpio info
INPUT  0:H 1:H 2:H 3:H
OUTPUT 0:L 1:L 2:L 3:L
```

The `set` subcommand assigns specified level to specified output pin. This command can accept 0 to 3 as index of output pins and 0 or 1 as the status. 
```
uart:~$ gpio set 0 1
[notice] parameter order [index] [status (0 or 1)]
```

The following shows that the status of output 0-pin and input 0-pin. These status changes are caused by the effect of above `set` subcommand. Because input 0-pin and output 0-pin are connected.
```
uart:~$ gpio info
INPUT  0:L 1:H 2:H 3:H
OUTPUT 0:H 1:L 2:L 3:L
```

The following results are from candump and cansend.

Following can message whose id is 0x212 means the input pin status. And the 7bit in its data means input 0-pin and 4bit in its data means input-3-pin. So the following result means the status of all input pins are high.
 
```
$ candump -c can1,212:7ff
  can1  212   [1]  F0
```

Following can message whose id is 0x211 means the assigning command to the output pin. The meaning of its data are same to above input status can message. So the following result means assigning high level to output 0-pin to and assigning low level to other pins.

```
$ cansend can1 211#80
```

After sending above can message, the input pin status can message was changed as following. This means that the status of input 0-pin has been changed into low level.
```
$ candump -c can1,212:7ff
  can1  212   [1]  70
```

[HWDEV-2086]: https://lexxpluss.atlassian.net/browse/HWDEV-2086?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ