### PR TITLE
HWDEV-2231 disable differential encoder for actuator

### DIFF
--- a/lexxpluss_apps/src/main.cpp
+++ b/lexxpluss_apps/src/main.cpp
@@ -118,7 +118,9 @@ void init_gpio() {
     gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(spare_gpio_9), gpios);
     if (gpio_is_ready_dt(&gpio_dev))
         gpio_pin_configure_dt(&gpio_dev, GPIO_OUTPUT_LOW | GPIO_ACTIVE_HIGH);
-
+    gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(d_enc_ena), gpios);
+    if (gpio_is_ready_dt(&gpio_dev))
+        gpio_pin_configure_dt(&gpio_dev, GPIO_OUTPUT_LOW | GPIO_ACTIVE_HIGH);
     
     // Input
     gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(ps_sw_in), gpios);


### PR DESCRIPTION
ref: [HWDEV-2231](https://lexxpluss.atlassian.net/browse/HWDEV-2231)

This PR is motivated to set low level to d_enc_ena pin to disable differential encoder.

[HWDEV-2231]: https://lexxpluss.atlassian.net/browse/HWDEV-2231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ