### PR TITLE
Hwdev 2162 add off wait state

### DIFF
--- a/lexxpluss_apps/src/board_controller.cpp
+++ b/lexxpluss_apps/src/board_controller.cpp
@@ -845,7 +845,7 @@ public:
         return ((data.mod_status1 & 0b10111111) == 0 ||
                 (data.mod_status2 & 0b11100001) == 0 ||
                 (data.bmu_alarm1  & 0b11111111) == 0 ||
-                (data.bmu_alarm2  & 0b00000001) == 0) || true;
+                (data.bmu_alarm2  & 0b00000001) == 0);
     }
     void get_fet_state(bool &c_fet, bool &d_fet, bool &p_dsg) {
         gpio_dt_spec gpio_c_dev = GET_GPIO(bmu_c_fet);

--- a/lexxpluss_apps/src/board_controller.cpp
+++ b/lexxpluss_apps/src/board_controller.cpp
@@ -1328,7 +1328,7 @@ private:
                 set_new_state(POWER_STATE::OFF);
             } else if (mbd.is_dead()) {
                 set_new_state(POWER_STATE::LOCKDOWN);
-            } else if (ksw.is_maintenance() || psw_state != power_switch::STATE::RELEASED || mbd.power_off_from_ros() || !bmu.is_ok()) {
+            } else if (psw_state != power_switch::STATE::RELEASED || mbd.power_off_from_ros() || !bmu.is_ok()) {
                 set_new_state(POWER_STATE::OFF_WAIT);
             } else if (ksw.is_maintenance()) {
                 LOG_DBG("maintenance mode is selected by key switch\n");
@@ -1388,7 +1388,7 @@ private:
                 set_new_state(POWER_STATE::OFF);
             } else if (mbd.is_dead()) {
                 set_new_state(POWER_STATE::LOCKDOWN);
-            } else if (ksw.is_maintenance() || psw_state != power_switch::STATE::RELEASED || mbd.power_off_from_ros() || !bmu.is_ok()) {
+            } else if (psw_state != power_switch::STATE::RELEASED || mbd.power_off_from_ros() || !bmu.is_ok()) {
                 set_new_state(POWER_STATE::OFF_WAIT);
             } else if (!ksw.is_maintenance() && !esw.is_asserted() && !mbd.emergency_stop_from_ros()) {
                 LOG_DBG("not emergency\n");
@@ -1484,7 +1484,7 @@ private:
             if (!dcdc.is_ok()) {
                 LOG_DBG("DCDC failure\n");
                 set_new_state(POWER_STATE::OFF);
-            } else if (ksw.is_maintenance() || psw.get_state() != power_switch::STATE::RELEASED) {
+            } else if (psw.get_state() != power_switch::STATE::RELEASED) {
                 LOG_DBG("detect power switch\n");
                 set_new_state(POWER_STATE::OFF);
             } else if (psw.is_activated_unlock()) {

--- a/lexxpluss_apps/src/power_state.hpp
+++ b/lexxpluss_apps/src/power_state.hpp
@@ -10,4 +10,5 @@ enum class POWER_STATE {
     TIMEROFF,
     SUSPEND,
     RESUME_WAIT,
+    OFF_WAIT,
 };


### PR DESCRIPTION
ref: [HWDEV-2162](https://lexxpluss.atlassian.net/browse/HWDEV-2162)

This PR is motivated to add OFF_WAIT state and improve power switch handling. OFF_WAIT state means waiting for power off. And it was created by extracting such process from STANDBY and SUSPEND. This modification let us turn the power off from any state. Because it is achieved by transition to OFF_WAIT state from any states. 

The modifications in this PR are followings.

* Add OFF_WAIT state for above reason
* Add raw_switch to handle switch device without any semantics
* Modify power_switch to use raw_switch to handle its switch device
* Remove redundant power_switch reset

[HWDEV-2162]: https://lexxpluss.atlassian.net/browse/HWDEV-2162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ