### PR TITLE
HWDEV-2243 add actuator_service_controller

### DIFF
--- a/lexxpluss_apps/src/actuator_service_controller.cpp
+++ b/lexxpluss_apps/src/actuator_service_controller.cpp
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2022, LexxPluss Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <optional>
+
+#include <zephyr/kernel.h>
+#include <zephyr/logging/log.h>
+#include "actuator_controller.hpp"
+#include "actuator_service_controller.hpp"
+
+namespace lexxhard::actuator_service_controller {
+
+LOG_MODULE_REGISTER(actuator_service);
+
+char __aligned(4) msgq_request_buffer[8 * sizeof (msg_request)];
+char __aligned(4) msgq_response_buffer[8 * sizeof (msg_response)];
+
+class actuators_service_controller_impl {
+public:
+    int init() {
+        k_msgq_init(&msgq_request, msgq_request_buffer, sizeof (msg_request), 8);
+        k_msgq_init(&msgq_response, msgq_response_buffer, sizeof (msg_response), 8);
+
+        return 0;
+    }
+
+    void run() {
+        while (true) {
+            struct msg_request msg_req;
+            if (k_msgq_get(&msgq_request, &msg_req, K_NO_WAIT) == 0) {
+                if(auto const ret(handle_request(msg_req)); ret.has_value()) {
+                    struct msg_response msg_resp{*ret};
+                    while(k_msgq_put(&msgq_response, &msg_resp, K_NO_WAIT) != 0)  {
+                        k_msgq_purge(&msgq_response);
+                    }
+                }
+            }
+            k_msleep(10);
+        }
+    }
+
+private:
+    std::optional<struct msg_response> handle_request(struct  msg_request const& msg_req)
+    {
+        if(msg_req.mode == service_mode::INIT_DOWN || msg_req.mode == service_mode::INIT_UP) {
+            return do_init_service(msg_req);
+        } else if(msg_req.mode == service_mode::LOCATION) {
+            return do_location_service(msg_req);
+        }
+
+        LOG_ERR("Invalid service mode: %d", static_cast<int8_t>(msg_req.mode));
+        return std::nullopt;
+    };
+
+    struct msg_response do_init_service(struct msg_request const& msg_req)
+    {
+        bool const ret{actuator_controller::init_location() == 0};
+        return {
+            .mode = msg_req.mode,
+            .success = ret,
+            .left = {.detail = 0},
+            .center = {.detail = 0},
+            .right = {.detail = 0},
+            .counter = msg_req.counter
+        };
+    }
+
+    struct msg_response do_location_service(struct msg_request const& msg_req)
+    {
+        uint8_t const location[3]{
+            msg_req.center.location,
+            msg_req.left.location,
+            msg_req.right.location
+        };
+        uint8_t const power[3]{
+            msg_req.center.power,
+            msg_req.left.power,
+            msg_req.right.power
+        };
+        uint8_t detail[3]{0, 0, 0};
+        bool const ret{actuator_controller::to_location(location, power, detail) == 0};
+
+        return {
+            .mode = msg_req.mode,
+            .success = ret,
+            .left = {.detail = detail[1]},
+            .center = {.detail = detail[0]},
+            .right = {.detail = detail[2]},
+            .counter = msg_req.counter
+        };
+    }
+} impl;
+
+void init()
+{
+    impl.init();
+}
+
+void run(void *p1, void *p2, void *p3)
+{
+    impl.run();
+}
+
+k_thread thread;
+k_msgq msgq_request, msgq_response;
+}

--- a/lexxpluss_apps/src/actuator_service_controller.hpp
+++ b/lexxpluss_apps/src/actuator_service_controller.hpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2022, LexxPluss Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <zephyr/kernel.h>
+
+namespace lexxhard::actuator_service_controller {
+
+enum class service_mode: int8_t {
+    INIT_DOWN = -1,
+    LOCATION = 0,
+    INIT_UP = 1,
+};
+
+struct msg_request {
+    service_mode mode;
+    struct {
+        uint8_t location;
+        uint8_t power;
+    } left, center, right;
+    uint8_t counter;
+
+    static msg_request from(uint8_t data[8]) {
+        return {
+            .mode = static_cast<service_mode>(data[0]),
+            .left = {data[1], data[4]},
+            .center = {data[2], data[5]},
+            .right = {data[3], data[6]},
+            .counter = data[7]
+        };
+    }
+} __attribute__((aligned(4)));
+
+struct msg_response {
+    service_mode mode;
+    bool success;
+    struct {
+        uint8_t detail;
+    } left, center, right;
+    uint8_t counter;
+
+    void into(uint8_t data[8]) {
+        data[0] = static_cast<int8_t>(mode);
+        data[1] = static_cast<uint8_t>(success);
+        data[2] = left.detail;
+        data[3] = center.detail;
+        data[4] = right.detail;
+        data[5] = 0;
+        data[6] = 0;
+        data[7] = counter;
+    }
+} __attribute__((aligned(4)));
+
+void init();
+void run(void *p1, void *p2, void *p3);
+extern k_thread thread;
+extern k_msgq msgq_request, msgq_response;
+}

--- a/lexxpluss_apps/src/main.cpp
+++ b/lexxpluss_apps/src/main.cpp
@@ -26,6 +26,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/gpio.h>
 #include "actuator_controller.hpp"
+#include "actuator_service_controller.hpp"
 #include "adc_reader.hpp"
 #include "board_controller.hpp"
 #include "can_controller.hpp"
@@ -43,6 +44,7 @@
 namespace {
 
 K_THREAD_STACK_DEFINE(actuator_controller_stack, 2048);
+K_THREAD_STACK_DEFINE(actuator_service_controller_stack, 2048);
 K_THREAD_STACK_DEFINE(adc_reader_stack, 2048);
 K_THREAD_STACK_DEFINE(bmu_controller_stack, 2048);
 K_THREAD_STACK_DEFINE(board_controller_stack, 2048);
@@ -260,6 +262,7 @@ int main()
     fan_on();
 
     lexxhard::actuator_controller::init();
+    lexxhard::actuator_service_controller::init();
     lexxhard::adc_reader::init();
     lexxhard::bmu_controller::init();
     lexxhard::board_controller::init();
@@ -275,6 +278,7 @@ int main()
     lexxhard::tug_encoder_controller::init();
 
     RUN(actuator_controller, 2);
+    RUN(actuator_service_controller, 2);
     RUN(adc_reader, 2);
     RUN(bmu_controller, 4);
     RUN(can_controller, 4);

--- a/lexxpluss_apps/src/zcan_actuator_service.hpp
+++ b/lexxpluss_apps/src/zcan_actuator_service.hpp
@@ -1,0 +1,104 @@
+/*
+ * Copyright (c) 2022, LexxPluss Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <algorithm>
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/gpio.h>
+#include <zephyr/drivers/can.h>
+#include <zephyr/logging/log.h>
+#include "actuator_service_controller.hpp"
+
+#define CAN_ID_ACTUATOR_SERVICE_REQUEST 0x20b // based on CAN ID assignment
+#define CAN_ID_ACTUATOR_SERVICE_RESPONSE 0x213 // based on CAN ID assignment
+#define CAN_DATALENGTH_ACTUATOR_SERVICE_REQUEST 8
+#define CAN_DATALENGTH_ACTUATOR_SERVICE_RESPONSE 8
+
+namespace lexxhard::zcan_actuator_service {
+
+LOG_MODULE_REGISTER(zcan_actuator_service);
+
+char __aligned(4) msgq_can_actuator_service_request_buffer[8 * sizeof (struct can_frame)];
+char __aligned(4) msgq_can_actuator_service_response_buffer[8 * sizeof (struct can_frame)];
+
+CAN_MSGQ_DEFINE(msgq_can_actuator_service_request, 16);
+
+class zcan_actuator_service {
+public:
+    void init() {
+        // can device bind
+        k_msgq_init(&msgq_can_actuator_service_request, msgq_can_actuator_service_request_buffer, sizeof(struct can_frame), 8);
+
+        dev = DEVICE_DT_GET(DT_NODELABEL(can2));
+        if (!device_is_ready(dev)){
+            LOG_ERR("CAN_2 is not ready");
+            return;
+        }
+
+        // setup can filter
+        static const can_filter filter_actuator_service_request{
+            .id{CAN_ID_ACTUATOR_SERVICE_REQUEST},
+            .mask{0x7ff}
+        };
+
+        can_add_rx_filter_msgq(dev, &msgq_can_actuator_service_request, &filter_actuator_service_request);
+        return;
+    }
+    void poll() {
+        handle_request();
+        handle_response();
+    }
+
+private:
+    void handle_request() {
+        struct can_frame can_frame;
+        while (k_msgq_get(&msgq_can_actuator_service_request, &can_frame, K_NO_WAIT) == 0) {
+            auto const msg{actuator_service_controller::msg_request::from(can_frame.data)};
+            while (k_msgq_put(&actuator_service_controller::msgq_request, &msg, K_NO_WAIT) != 0) {
+                k_msgq_purge(&actuator_service_controller::msgq_request);
+            }
+        }
+    }
+
+    void handle_response() {
+        actuator_service_controller::msg_response msg;
+        while (k_msgq_get(&actuator_service_controller::msgq_response, &msg, K_NO_WAIT) == 0) {
+            struct can_frame can_frame{
+                .id = CAN_ID_ACTUATOR_SERVICE_RESPONSE,
+                .dlc = CAN_DATALENGTH_ACTUATOR_SERVICE_RESPONSE,
+            };
+            msg.into(can_frame.data);
+            can_send(dev, &can_frame, K_MSEC(100), nullptr, nullptr);    //accel
+        }
+    }
+
+    const device *dev{nullptr};
+};
+
+}
+

--- a/lexxpluss_apps/src/zcan_main.cpp
+++ b/lexxpluss_apps/src/zcan_main.cpp
@@ -25,6 +25,7 @@
 
 #include <zephyr/logging/log.h>
 #include "zcan_actuator.hpp"
+#include "zcan_actuator_service.hpp"
 #include "zcan_bmu.hpp"
 #include "zcan_board.hpp"
 #include "zcan_imu.hpp"
@@ -58,6 +59,7 @@ public:
         board.init();
         dfu.init();
         act.init();
+        act_srv.init();
         imu.init();
         led.init();
         pgv.init();
@@ -72,6 +74,7 @@ public:
             board.poll();
             dfu.poll();
             act.poll();
+            act_srv.poll();
             imu.poll();
             led.poll();
             pgv.poll();
@@ -87,6 +90,7 @@ private:
     lexxhard::zcan_board::zcan_board board;
     lexxhard::zcan_dfu::zcan_dfu dfu;
     lexxhard::zcan_actuator::zcan_actuator act;
+    lexxhard::zcan_actuator_service::zcan_actuator_service act_srv;
     lexxhard::zcan_imu::zcan_imu imu;
     lexxhard::zcan_led::zcan_led led;
     lexxhard::zcan_pgv::zcan_pgv pgv;


### PR DESCRIPTION
ref: [HWDEV-2243](https://lexxpluss.atlassian.net/browse/HWDEV-2243)

This PR is motivated to support controlling actuator by specifying locations. 

In the current implementation, controlling actuator by specifying location is achieved to call `to_location` function. And this function is designed to be called by other context. Because it waits for actuator location fixed.
So I added new thread whose name is `actuator_service_controller`. This thread handles actuator service requests and responses.


[HWDEV-2243]: https://lexxpluss.atlassian.net/browse/HWDEV-2243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ