### PR TITLE
Hwdev 2091 add safety lidar output handling

### DIFF
--- a/lexxpluss_apps/src/board_controller.cpp
+++ b/lexxpluss_apps/src/board_controller.cpp
@@ -1162,6 +1162,7 @@ public:
         ossd2_value = (gpio_pin_get_dt(&ossd2_dev) == 1);
     }
     bool is_asserted() const {
+        // assert when ossd1 and ossd2 are low level
         return !ossd1_value && !ossd2_value;
     }
     void request_reset() {

--- a/lexxpluss_apps/src/board_controller.cpp
+++ b/lexxpluss_apps/src/board_controller.cpp
@@ -1145,6 +1145,7 @@ public:
             should_reset = false;
             // Reset the safety lidar here if needed
             // For now, we cannot reset the safety lidar because reset pin is not connected
+            LOG_INF("safety_lidar doesn't support reset for now");
             return;
         }
 

--- a/lexxpluss_apps/src/board_controller.cpp
+++ b/lexxpluss_apps/src/board_controller.cpp
@@ -1175,7 +1175,6 @@ private:
     bool should_reset{false};
 };
 
-
 #define WDT_TIMEOUT_MS 10000
 #define FAN_DUTY_DEFAULT 100
 class state_controller { // Variables Implemented

--- a/lexxpluss_apps/src/can_controller.cpp
+++ b/lexxpluss_apps/src/can_controller.cpp
@@ -116,7 +116,7 @@ public:
     }
     void brd_info(const shell *shell) const {
         shell_print(shell,
-                    "Bumper:%d Emergency:%d Power:%d\n"
+                    "Bumper:%d Emergency:%d SafetyLiDAR:%d Power:%d\n"
                     "Shutdown:%d Reason:%d AutoCharge:%d ManualCharge:%d\n"
                     "CFET:%d DFET:%d PDSG:%d\n"
                     "V24_PG:%d VPERIPH_PG:%d VWHEEL_L_PG:%d VWHEEL_R_PG:%d\n"
@@ -126,7 +126,7 @@ public:
                     "Lockdown:%s\n"
                     "Charge Connector Voltage:%f Count:%u Delay:%u ChargeTempGood:%d\n"
                     "Version:%s\n",
-                    board2ros.bumper_switch_asserted, board2ros.emergency_switch_asserted, board2ros.power_switch_state,
+                    board2ros.bumper_switch_asserted, board2ros.emergency_switch_asserted, board2ros.safety_lidar_asserted, board2ros.power_switch_state,
                     board2ros.wait_shutdown_state, board2ros.shutdown_reason, board2ros.auto_charging_status, board2ros.manual_charging_status,
                     board2ros.c_fet, board2ros.d_fet, board2ros.p_dsg,
                     board2ros.v24_pgood, board2ros.v_peripheral_pgood, board2ros.v_wheel_motor_l_pgood, board2ros.v_wheel_motor_r_pgood,

--- a/lexxpluss_apps/src/can_controller.hpp
+++ b/lexxpluss_apps/src/can_controller.hpp
@@ -52,6 +52,7 @@ struct msg_board {
     uint8_t fan_duty, shutdown_reason, state, charge_check_count, charge_heartbeat_delay;
     bool bumper_switch_asserted;
     bool emergency_switch_asserted;
+    bool safety_lidar_asserted;
     bool power_switch_state, wait_shutdown_state, auto_charging_status, manual_charging_status;
     bool c_fet, d_fet, p_dsg;
     bool is_activated_battery;

--- a/lexxpluss_apps/src/main.cpp
+++ b/lexxpluss_apps/src/main.cpp
@@ -123,6 +123,12 @@ void init_gpio() {
     gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(d_enc_ena), gpios);
     if (gpio_is_ready_dt(&gpio_dev))
         gpio_pin_configure_dt(&gpio_dev, GPIO_OUTPUT_LOW | GPIO_ACTIVE_HIGH);
+    gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(safety_lidar_res_req1), gpios);
+    if (gpio_is_ready_dt(&gpio_dev))
+        gpio_pin_configure_dt(&gpio_dev, GPIO_OUTPUT_LOW | GPIO_ACTIVE_HIGH);
+    gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(safety_lidar_res_req2), gpios);
+    if (gpio_is_ready_dt(&gpio_dev))
+        gpio_pin_configure_dt(&gpio_dev, GPIO_OUTPUT_LOW | GPIO_ACTIVE_HIGH);
     
     // Input
     gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(ps_sw_in), gpios);
@@ -182,6 +188,18 @@ void init_gpio() {
     gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(spare_gpio_13), gpios);
     if (gpio_is_ready_dt(&gpio_dev))
         gpio_pin_configure_dt(&gpio_dev, GPIO_INPUT | GPIO_PULL_UP | GPIO_ACTIVE_HIGH);
+    gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(safety_lidar_ossd1), gpios);
+    if (gpio_is_ready_dt(&gpio_dev))
+        gpio_pin_configure_dt(&gpio_dev, GPIO_INPUT | GPIO_ACTIVE_HIGH);
+    gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(safety_lidar_ossd2), gpios);
+    if (gpio_is_ready_dt(&gpio_dev))
+        gpio_pin_configure_dt(&gpio_dev, GPIO_INPUT | GPIO_ACTIVE_HIGH);
+    gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(safety_lidar_ossd3), gpios);
+    if (gpio_is_ready_dt(&gpio_dev))
+        gpio_pin_configure_dt(&gpio_dev, GPIO_INPUT | GPIO_ACTIVE_HIGH);
+    gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(safety_lidar_ossd4), gpios);
+    if (gpio_is_ready_dt(&gpio_dev))
+        gpio_pin_configure_dt(&gpio_dev, GPIO_INPUT | GPIO_ACTIVE_HIGH);
 
     // LED
     gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(dbg_led1), gpios);

--- a/lexxpluss_apps/src/main.cpp
+++ b/lexxpluss_apps/src/main.cpp
@@ -123,12 +123,6 @@ void init_gpio() {
     gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(d_enc_ena), gpios);
     if (gpio_is_ready_dt(&gpio_dev))
         gpio_pin_configure_dt(&gpio_dev, GPIO_OUTPUT_LOW | GPIO_ACTIVE_HIGH);
-    gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(safety_lidar_res_req1), gpios);
-    if (gpio_is_ready_dt(&gpio_dev))
-        gpio_pin_configure_dt(&gpio_dev, GPIO_OUTPUT_LOW | GPIO_ACTIVE_HIGH);
-    gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(safety_lidar_res_req2), gpios);
-    if (gpio_is_ready_dt(&gpio_dev))
-        gpio_pin_configure_dt(&gpio_dev, GPIO_OUTPUT_LOW | GPIO_ACTIVE_HIGH);
     
     // Input
     gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(ps_sw_in), gpios);
@@ -198,6 +192,12 @@ void init_gpio() {
     if (gpio_is_ready_dt(&gpio_dev))
         gpio_pin_configure_dt(&gpio_dev, GPIO_INPUT | GPIO_ACTIVE_HIGH);
     gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(safety_lidar_ossd4), gpios);
+    if (gpio_is_ready_dt(&gpio_dev))
+        gpio_pin_configure_dt(&gpio_dev, GPIO_INPUT | GPIO_ACTIVE_HIGH);
+    gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(safety_lidar_res_req1), gpios);
+    if (gpio_is_ready_dt(&gpio_dev))
+        gpio_pin_configure_dt(&gpio_dev, GPIO_INPUT | GPIO_ACTIVE_HIGH);
+    gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(safety_lidar_res_req2), gpios);
     if (gpio_is_ready_dt(&gpio_dev))
         gpio_pin_configure_dt(&gpio_dev, GPIO_INPUT | GPIO_ACTIVE_HIGH);
 

--- a/lexxpluss_apps/src/zcan_board.hpp
+++ b/lexxpluss_apps/src/zcan_board.hpp
@@ -84,6 +84,9 @@ public:
             if (message.emergency_stop) {
                 packedData[0] |= 0b00000100;
             }
+            if (message.safety_lidar_asserted) {
+                packedData[0] |= 0b00000010;
+            }
 
             if (message.auto_charging_status){
                 packedData[1] = 0x01;


### PR DESCRIPTION
ref: [HWDEV-2091](https://lexxpluss.atlassian.net/browse/HWDEV-2091)

This PR is motivated to handle safety lidar ossd output. This PR contains following.

* Polling ossd output from safety lidary and assert when two ossd output are low
* Translate power state from STANDBY, NORMAL, RESUME_WAIT or AUTO_CHARGE into SUSPEND when safety lidar asserted
* Send safety lidar status in the 1st bit of 0th byte in can message whose id is 0x20C

This PR is checked in robot as following.

**objects are not in safety zone**

shell 
```
uart:~$ brd info
Bumper:0 Emergency:0 SafetyLiDAR:0 Power:0
Shutdown:0 Reason:0 AutoCharge:0 ManualCharge:1
CFET:1 DFET:1 PDSG:1
V24_PG:0 VPERIPH_PG:0 VWHEEL_L_PG:1 VWHEEL_R_PG:1
STATE:6 WHEEL:0
FAN:100
ConnTemp:P 28 N 25
Lockdown:enable
Charge Connector Voltage:16.000000 Count:0 Delay:255 ChargeTempGood:0
Version:3.0.2
```

can dump
```
...
can1  20C   [6]  04 00 00 FF 00 14
can1  20C   [6]  04 00 00 FF 00 14
```

**objects are in safety zone**

shell
```
uart:~$ brd info
Bumper:0 Emergency:0 SafetyLiDAR:1 Power:0
Shutdown:0 Reason:0 AutoCharge:0 ManualCharge:1
CFET:1 DFET:1 PDSG:1
V24_PG:0 VPERIPH_PG:0 VWHEEL_L_PG:1 VWHEEL_R_PG:1
STATE:6 WHEEL:0
FAN:100
ConnTemp:P 28 N 25
Lockdown:enable
Charge Connector Voltage:17.000000 Count:0 Delay:255 ChargeTempGood:0
Version:3.0.2
```
can dump
```
...
can1  20C   [6]  06 00 00 FF 00 14
can1  20C   [6]  06 00 00 FF 00 14
```




[HWDEV-2091]: https://lexxpluss.atlassian.net/browse/HWDEV-2091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ