### PR TITLE
HWDEV-2284 add wait for dcdc output ready

### DIFF
--- a/lexxpluss_apps/src/board_controller.cpp
+++ b/lexxpluss_apps/src/board_controller.cpp
@@ -1606,6 +1606,10 @@ private:
             }
             gpio_pin_set_dt(&gpio_dev, bat_out_state);
             ac.set_enable(false);
+
+            // Wait for dcdc is ready
+            // 500[ms] is NG, 1000[ms] is OK by test
+            k_msleep(1000);
         } break;
         case POWER_STATE::NORMAL: {
             LOG_INF("enter NORMAL\n");


### PR DESCRIPTION
ref: [HWDEV-2284](https://lexxpluss.atlassian.net/browse/HWDEV-2284)

This PR is motivated to add workaround for shutdown caused by wrong dcdc output observation.  In the current implementation of PDB, its output becomes unstable for some duration when it's output for wheels are enabled. Concretely, it is as followings.

* It takes about 500[ms] to enable output for wheels
* After output for wheels is enabled, 24v output shutdown momentary.

To avoid above situations, this PR add a 1000[ms] wait for dcdc output is stable. 

This PR is checked in real  robot. And it worked as expected.

log from original implementation. It shows that robot was shutdown by wrong dcdc output.
```
[00:00:12.508,000] <inf> board: leave WAIT_SW
[00:00:12.508,000] <inf> board: enter POST
[00:00:14.145,000] <inf> board: leave POST
[00:00:14.145,000] <inf> board: enter STANDBY
[00:00:20.166,000] <err> board: gpio_pgood_wheel_motor_left_dev NG
[00:00:20.166,000] <err> board: gpio_pgood_wheel_motor_right_dev NG
[00:00:20.166,000] <err> board: dcdc is_ok() NG: 0
[00:00:20.166,000] <inf> board: leave STANDBY
[00:00:20.166,000] <inf> board: enter OFF
[00:00:26.192,000] <inf> board: leave OFF
[00:00:26.192,000] <inf> board: enter WAIT_SW
```

log from this PR. It shows that there are no errors.
```
[00:00:16.351,000] <inf> board: leave WAIT_SW
[00:00:16.351,000] <inf> board: enter POST
[00:00:18.175,000] <inf> board: leave POST
[00:00:18.175,000] <inf> board: enter STANDBY
[00:00:25.195,000] <inf> board: leave STANDBY
[00:00:25.195,000] <inf> board: enter SUSPEND
```

[HWDEV-2284]: https://lexxpluss.atlassian.net/browse/HWDEV-2284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ