### PR TITLE
Hwdev 2326 fix actuator control issue

### DIFF
--- a/lexxpluss_apps/src/actuator_controller.cpp
+++ b/lexxpluss_apps/src/actuator_controller.cpp
@@ -206,6 +206,11 @@ public:
     int16_t get() const {
         return count;
     }
+    void reset() {
+        ch1_prev = ch2_prev = 0;
+        count = 0;
+        is_rise_edge = false;
+    }
 private:
     static void static_center_enc_callback(struct k_timer *timer_id) {
         auto* instance = static_cast<encoder*>(k_timer_user_data_get(timer_id));
@@ -339,6 +344,7 @@ public:
 private:
     void reset_pulse() {
         pulse_value = prev_pulse_value = 0;
+        enc.reset();
     }
     void wait_stabilize() {
         for (int i{0}; i < 10; ++i) {

--- a/lexxpluss_apps/src/actuator_controller.hpp
+++ b/lexxpluss_apps/src/actuator_controller.hpp
@@ -31,27 +31,45 @@ namespace lexxhard::actuator_controller {
 
 struct can_format_encoder {
     can_format_encoder(int16_t enc0,int16_t enc1,int16_t enc2) : encoder_count{enc0, enc1, enc2} {} 
-    int16_t encoder_count[3]; // Center / Left / Right
+    int16_t encoder_count[3]; // Left / Center / Right
+    void into(uint8_t data[8]) {
+        data[0] = static_cast<uint8_t>((encoder_count[0] >> 8) & 0xff);
+        data[1] = static_cast<uint8_t>(encoder_count[0] & 0xff);
+        data[2] = static_cast<uint8_t>((encoder_count[1] >> 8) & 0xff);
+        data[3] = static_cast<uint8_t>(encoder_count[1] & 0xff);
+        data[4] = static_cast<uint8_t>((encoder_count[2] >> 8) & 0xff);
+        data[5] = static_cast<uint8_t>(encoder_count[2] & 0xff); 
+    }
 } __attribute__((aligned(4)));
 
 struct can_format_current {
     can_format_current(int16_t cur0,int16_t cur1,int16_t cur2, int16_t con) : current_mv{cur0, cur1, cur2}, connection_mv(con) {} 
-    int16_t current_mv[3]; // Center / Left / Right
+    int16_t current_mv[3]; // Left / Center / Right
     int16_t connection_mv;
+    void into(uint8_t data[8]) {
+        data[0] = static_cast<uint8_t>((current_mv[0] >> 8) & 0xff);
+        data[1] = static_cast<uint8_t>(current_mv[0] & 0xff);
+        data[2] = static_cast<uint8_t>((current_mv[1] >> 8) & 0xff);
+        data[3] = static_cast<uint8_t>(current_mv[1] & 0xff);
+        data[4] = static_cast<uint8_t>((current_mv[2] >> 8) & 0xff);
+        data[5] = static_cast<uint8_t>(current_mv[2] & 0xff);
+        data[6] = static_cast<uint8_t>((connection_mv >> 8) & 0xff);
+        data[7] = static_cast<uint8_t>(connection_mv & 0xff);
+    }
 } __attribute__((aligned(4)));
 
 struct msg_control {
     struct {
         int8_t direction; // -1:down, 0:stop, 1:up
         uint8_t power;    // 0-100 duty[%]
-    } actuators[3];
+    } actuators[3]; // Left / Center / Right
     static constexpr int8_t DOWN{-1}, STOP{0}, UP{1};
     static msg_control from(const uint8_t data[8]) {
         return {
             .actuators{
-                {static_cast<int8_t>(data[1]), data[4]}, // Center
-                {static_cast<int8_t>(data[0]), data[3]}, // Left
-                {static_cast<int8_t>(data[2]), data[5]}  // Right
+                {static_cast<int8_t>(data[0]), data[3]},
+                {static_cast<int8_t>(data[1]), data[4]},
+                {static_cast<int8_t>(data[2]), data[5]}
             }
         };
     }

--- a/lexxpluss_apps/src/zcan_actuator.hpp
+++ b/lexxpluss_apps/src/zcan_actuator.hpp
@@ -74,14 +74,14 @@ public:
                 .dlc = CAN_DATALENGTH_ACTUATOR_ENCODER
             };
             actuator_controller::can_format_encoder tmp_enc = actuator_controller::can_format_encoder(message.encoder_count[0], message.encoder_count[1], message.encoder_count[2]);
-            memcpy(can_frame_actuator_encoder.data, &tmp_enc, CAN_DATALENGTH_ACTUATOR_ENCODER);
+            tmp_enc.into(can_frame_actuator_encoder.data);
 
             can_frame can_frame_actuator_current{
                 .id = CAN_ID_ACTUATOR_CURRENT,
                 .dlc = CAN_DATALENGTH_ACTUATOR_CURRENT
             };
             actuator_controller::can_format_current tmp_cur = actuator_controller::can_format_current(message.current[0], message.current[1], message.current[2], message.connect);
-            memcpy(can_frame_actuator_current.data, &tmp_cur, CAN_DATALENGTH_ACTUATOR_CURRENT);
+            tmp_cur.into(can_frame_actuator_current.data);
 
             can_send(dev, &can_frame_actuator_encoder, K_MSEC(100), nullptr, nullptr);
             can_send(dev, &can_frame_actuator_current, K_MSEC(100), nullptr, nullptr);


### PR DESCRIPTION
ref: [HWDEV-2326](https://lexxpluss.atlassian.net/browse/HWDEV-2326)

This PR is motivated to fix actuator not controlled in ROS layer issue. This issue was caused by using wrong encoder value . So this PR fixed them by followings.

* Reset encoder value when actuator initialized
* Use Big Endian when encoder value sent via can
* Fix encoder value order of can message from Cener, Left, Right to Left, Center, Right. Converting from robot roder (LCR) to ROS order (CRL) is achieved in SCBDriver

This PR is tested in robot.

[HWDEV-2326]: https://lexxpluss.atlassian.net/browse/HWDEV-2326?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ