### PR TITLE
HWDEV-2091 wait until safety lidar launched in transition from stanby…

### DIFF
--- a/lexxpluss_apps/src/board_controller.cpp
+++ b/lexxpluss_apps/src/board_controller.cpp
@@ -1383,10 +1383,7 @@ private:
             } else if (esw.is_asserted()) {
                 LOG_DBG("emergency switch asserted\n");
                 set_new_state(POWER_STATE::SUSPEND);
-            } else if (sl.is_asserted()) {
-                LOG_DBG("safety lidar asserted\n");
-                set_new_state(POWER_STATE::SUSPEND);
-            } else if (!esw.is_asserted() && !mbd.emergency_stop_from_ros() && mbd.is_ready()) {
+            } else if (!esw.is_asserted() && !mbd.emergency_stop_from_ros() && mbd.is_ready() && !sl.is_asserted()) {
                 LOG_DBG("not emergency and heartbeat OK\n");
                 set_new_state(POWER_STATE::NORMAL);
             } else if (mc.is_plugged()) {


### PR DESCRIPTION
ref [HWDEV-2091](https://lexxpluss.atlassian.net/browse/HWDEV-2091)

This PR is motivated to wait until safety lidar launched in STANDBY state. This feature is needed not to turn into SUSPEND state when AMR is launched. Because the OSSD outputs from safety lidar are low until it launched and this means that safety lidar emits emergency states. But this emission of emergency from safety lidar are cleared when safety lidar are  launched. 

[HWDEV-2091]: https://lexxpluss.atlassian.net/browse/HWDEV-2091?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ