### PR TITLE
HWDEV-2285 fix wrong led indicator in power down sequence

### DIFF
--- a/lexxpluss_apps/src/board_controller.cpp
+++ b/lexxpluss_apps/src/board_controller.cpp
@@ -1081,7 +1081,15 @@ private:
 class boardstate_controller {  // No pins declared
 public:
     void init() {
+        reset();
         k_msgq_init(&msgq_board_pb_rx, msgq_board_pb_rx_buffer, sizeof (msg_rcv_pb), 8);
+    }
+    void reset() {
+        heartbeat_detect = false;
+        ros_heartbeat_timeout = false;
+        emergency_stop = true;
+        power_off = false;
+        wheel_poweroff = false;
     }
     void poll() {
         msg_rcv_pb msg;
@@ -1335,7 +1343,7 @@ private:
 
         switch (state) {
         case POWER_STATE::OFF:
-            if (ksw.is_maintenance()) {
+            if (ksw.is_maintenance() || is_lockdown) {
                 // empty here
             } else if(psw.get_state() == power_switch::STATE::RELEASED){
                 set_new_state(POWER_STATE::WAIT_SW);
@@ -1619,13 +1627,14 @@ private:
         case POWER_STATE::OFF: {
             LOG_INF("enter OFF\n");
             poweron_by_switch = false;
+            mbd.reset();
             psw.set_led(false);
             rsw.set_led(false);
             bsw.request_reset();
             dcdc.set_enable(false);
 
             // Set LED OFF
-            led_controller::msg const msg_led{led_controller::msg::NONE, 0};
+            led_controller::msg const msg_led{led_controller::msg::NONE, 0, 1};
             while (k_msgq_put(&led_controller::msgq, &msg_led, K_NO_WAIT) != 0)
                 k_msgq_purge(&led_controller::msgq);
         } break;
@@ -1721,6 +1730,7 @@ private:
         } break;
         case POWER_STATE::LOCKDOWN: {
             LOG_INF("enter LOCKDOWN\n");
+            is_lockdown = true;
             wsw.set_disable(true);
             gpio_dt_spec gpio_dev = GET_GPIO(v_wheel);
             if (!gpio_is_ready_dt(&gpio_dev)) {
@@ -1731,14 +1741,14 @@ private:
             ac.set_enable(false);
 
             // Set LED
-            led_controller::msg const msg_led{led_controller::msg::LOCKDOWN, 1000000000};
+            led_controller::msg const msg_led{led_controller::msg::LOCKDOWN, 1000000000, 10};
             while (k_msgq_put(&led_controller::msgq, &msg_led, K_NO_WAIT) != 0)
                 k_msgq_purge(&led_controller::msgq);
         } break;
         case POWER_STATE::OFF_WAIT: {
             LOG_INF("enter OFF_WAIT\n");
             timer_shutdown = k_uptime_get();    // timer reset
-            if (psw.get_state() == power_switch::STATE::PUSHED)
+            if (psw.get_state() == power_switch::STATE::PUSHED || ksw.is_maintenance())
                 shutdown_reason = SHUTDOWN_REASON::SWITCH;
             if (mbd.power_off_from_ros())
                 shutdown_reason = SHUTDOWN_REASON::ROS;
@@ -1746,7 +1756,7 @@ private:
                 shutdown_reason = SHUTDOWN_REASON::BMU;
 
             // Set LED
-            led_controller::msg const msg_led{led_controller::msg::SHOWTIME, 0};
+            led_controller::msg const msg_led{led_controller::msg::SHOWTIME, 60000};
             while (k_msgq_put(&led_controller::msgq, &msg_led, K_NO_WAIT) != 0)
                 k_msgq_purge(&led_controller::msgq);
         } break;
@@ -1835,7 +1845,7 @@ private:
     k_timer current_check_timeout, charge_guard_timeout;
     const device *dev_wdi{nullptr};
     bool poweron_by_switch{false}, current_check_enable{false}, charge_guard_asserted{false},
-         last_wheel_poweroff{false};
+         last_wheel_poweroff{false}, is_lockdown{false};
 } impl;
 
 int cmd_power_on(const shell *shell, size_t argc, char **argv)

--- a/lexxpluss_apps/src/led_controller.cpp
+++ b/lexxpluss_apps/src/led_controller.cpp
@@ -49,14 +49,20 @@ public:
     bool get_message(msg &output) {
         bool updated{false};
         if (msg message_new; k_msgq_get(&msgq, &message_new, K_MSEC(DELAY_MS)) == 0) {
-            if (message.interrupt_ms > 0) {
+            if (message.priority < message_new.priority) {
+                LOG_INF("interrupted pattern %u %ums %dpri", message_new.pattern, message_new.interrupt_ms, message_new.priority);
+                message_interrupted = message;
+                cycle_interrupted = k_cycle_get_32();
+                message = message_new;
+                updated = true;
+            } else if (message.interrupt_ms > 0) {
                 if (message_new.interrupt_ms == 0) {
                     message_interrupted = message_new;
                 }
             } else {
                 if (is_new_message(message_new)) {
                     if (message_new.interrupt_ms > 0) {
-                        LOG_INF("interrupted pattern %u %ums", message_new.pattern, message_new.interrupt_ms);
+                        LOG_INF("interrupted pattern %u %ums %dpri", message_new.pattern, message_new.interrupt_ms, message_new.priority);
                         message_interrupted = message;
                         cycle_interrupted = k_cycle_get_32();
                     }

--- a/lexxpluss_apps/src/led_controller.hpp
+++ b/lexxpluss_apps/src/led_controller.hpp
@@ -39,8 +39,8 @@ struct can_format {
 
 struct msg {
     msg() : pattern(NONE), interrupt_ms(0) {}
-    msg(uint32_t pattern, uint32_t interrupt_ms) :
-        pattern(pattern), interrupt_ms(interrupt_ms) {}
+    msg(uint32_t pattern, uint32_t interrupt_ms, uint8_t priority=0) :
+        pattern(pattern), interrupt_ms(interrupt_ms), priority(priority) {}
     msg(can_format frame) : pattern(frame.pattern), cpm(frame.count_per_minutes), rgb{frame.rgb[0],frame.rgb[1],frame.rgb[2]} {}
 
     msg(const char *str) {
@@ -104,6 +104,7 @@ struct msg {
     uint8_t pattern{NONE};
     uint32_t interrupt_ms{0}, cpm{0};
     uint8_t rgb[3]{0, 0, 0};
+    uint8_t priority{0};
     static constexpr uint8_t NONE{0};
     static constexpr uint8_t EMERGENCY_STOP{1};
     static constexpr uint8_t AMR_MODE{2};


### PR DESCRIPTION
ref: [HWDEV-2285](https://lexxpluss.atlassian.net/browse/HWDEV-2285)

This PR is motivated to fix wrong LED indicator in power down sequence. This issue was caused by wrong LED pattern interruptions. Concrete scenario is following.

1. When scb turns into OFF_WAIT state, SHOWTIME pattern is shown in LED
2. If amr sends a request to show other pattern in LED, above SHOWTIME pattern is interrupted. This is undesired behavior. 

To solve this issue, this PR contains following modifications.

* Add interrupt_ms value to above SHOWTIME command to prevent undesired interruptions. This value are already set  in v6 codes. I removed it by mistake.
* Add a priority field to LED message to force to override or protect LED pattern. This is used to override NONE pattern in turning into OFF state and protect any requests in SHOWING LOCKDOWN pattern.
* Reset boardstate_controller's internal values when turning into OFF state. This feature is needed to restart machine with preserving main-switch on. 

This PR is checked in robot and it worked.

[HWDEV-2285]: https://lexxpluss.atlassian.net/browse/HWDEV-2285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ