### PR TITLE
HWDEV-2324 improve workflow and build task

### DIFF
--- a/.github/assign-label-rules.yml
+++ b/.github/assign-label-rules.yml
@@ -1,0 +1,11 @@
+feat:
+  - head-branch: ['^feat']
+fix:
+  - head-branch: ['^fix']
+chore:
+  - head-branch: ['^chore']
+  - head-branch: ['^refactor']
+  - head-branch: ['^style']
+  - head-branch: ['^ci']
+doc:
+  - head-branch: ['^doc']

--- a/.github/assign-label-rules.yml
+++ b/.github/assign-label-rules.yml
@@ -1,11 +1,11 @@
 feat:
-  - head-branch: ['^feat']
+  - head-branch: ['-feat-']
 fix:
-  - head-branch: ['^fix']
+  - head-branch: ['-fix-']
 chore:
-  - head-branch: ['^chore']
-  - head-branch: ['^refactor']
-  - head-branch: ['^style']
-  - head-branch: ['^ci']
+  - head-branch: ['-chore-']
+  - head-branch: ['-refactor-']
+  - head-branch: ['-style-']
+  - head-branch: ['-ci-']
 doc:
-  - head-branch: ['^doc']
+  - head-branch: ['-doc-']

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,32 @@
+name-template: 'v$RESOLVED_VERSION 🌈'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    label: 'feat'
+  - title: '🐛 Bug Fixes'
+    label: 'fix'
+  - title: '🧰 Maintenance'
+    labels: 'chore'
+  - title: '📚 Documentation'
+    label: 'doc'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+      - 'feature'
+      - 'fix'
+  patch:
+    labels:
+      - 'patch'
+      - 'chore'
+      - 'doc'
+  default: minor
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/assign-label.yml
+++ b/.github/workflows/assign-label.yml
@@ -1,0 +1,20 @@
+#derived from https://qiita.com/ucan-lab/items/4b02dec969df399253f7
+name: Assign Label
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  assign-label:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/labeler@v5
+        if: ${{ github.event.action == 'opened' }}
+        with:
+          configuration-path: .github/assign-label-rules.yml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,9 +42,9 @@ jobs:
         id: build
         run: |
           set -e
-          make IN_HOST=1 setup
-          make IN_HOST=1 bootloader
-          make IN_HOST=1 firmware
+          make IN_HOST=1 WORKDIR=$(pwd) setup
+          make IN_HOST=1 WORKDIR=$(pwd) bootloader
+          make IN_HOST=1 WORKDIR=$(pwd) firmware
       - name: Notification
         uses: act10ns/slack@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,6 @@ jobs:
     runs-on: lp-4core-runner
     container:
       image: zephyrprojectrtos/zephyr-build:v0.26.9
-      options: --user root
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
@@ -43,13 +42,9 @@ jobs:
         id: build
         run: |
           set -e
-          cp -a /home/user/.cmake $HOME
-          west init -l lexxpluss_apps
-          west update
-          west config --global zephyr.base-prefer configfile
-          west zephyr-export
-          west build -b lexxpluss_scb bootloader/mcuboot/boot/zephyr -d build-mcuboot -- -DBOARD_ROOT=$(pwd)/extra
-          west build -b lexxpluss_scb lexxpluss_apps -- -DBOARD_ROOT=$(pwd)/extra -DZEPHYR_EXTRA_MODULES=$(pwd)/extra
+          make IN_HOST=1 setup
+          make IN_HOST=1 bootloader
+          make IN_HOST=1 firmware
       - name: Notification
         uses: act10ns/slack@v1
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,7 @@ jobs:
         id: build
         run: |
           set -e
+          cp -a /home/user/.cmake $HOME
           make IN_HOST=1 WORKDIR=$(pwd) setup
           make IN_HOST=1 WORKDIR=$(pwd) bootloader
           make IN_HOST=1 WORKDIR=$(pwd) firmware

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,24 @@
+name: Release Drafter
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Release Drafter
+        uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,7 +5,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize]
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,6 @@ jobs:
     runs-on: lp-4core-runner
     container:
       image: zephyrprojectrtos/zephyr-build:v0.26.9
-      options: --user root
     env:
       SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
     steps:
@@ -41,16 +40,10 @@ jobs:
         id: build
         run: |
           set -e
-          cp -a /home/user/.cmake $HOME
-          west init -l lexxpluss_apps
-          west update
-          west config --global zephyr.base-prefer configfile
-          west zephyr-export
-          west build -b lexxpluss_scb bootloader/mcuboot/boot/zephyr -d build-mcuboot -- -DBOARD_ROOT=$(pwd)/extra
-          west build -b lexxpluss_scb lexxpluss_apps -- -DBOARD_ROOT=$(pwd)/extra -DZEPHYR_EXTRA_MODULES=$(pwd)/extra
-          dd if=/dev/zero bs=1k count=256 | tr "\000" "\377" > bl_with_ff.bin
-          dd if=build-mcuboot/zephyr/zephyr.bin of=bl_with_ff.bin conv=notrunc
-          cat bl_with_ff.bin build/zephyr/zephyr.signed.bin > firmware.bin
+          make IN_HOST=1 setup
+          make IN_HOST=1 bootloader
+          make IN_HOST=1 firmware
+          make IN_HOST=1 initial
       - name: release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,7 @@ jobs:
         id: build
         run: |
           set -e
+          cp -a /home/user/.cmake $HOME
           make IN_HOST=1 WORKDIR=$(pwd) setup
           make IN_HOST=1 WORKDIR=$(pwd) bootloader
           make IN_HOST=1 WORKDIR=$(pwd) VERSION=${{ env.version }} firmware

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,14 +38,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-
+      - name: Extract version from tag
+        run: echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_ENV
       - name: build
         id: build
         run: |
           set -e
           make IN_HOST=1 WORKDIR=$(pwd) setup
           make IN_HOST=1 WORKDIR=$(pwd) bootloader
-          make IN_HOST=1 WORKDIR=$(pwd) VERSION=${{ github.ref_name }} firmware
+          make IN_HOST=1 WORKDIR=$(pwd) VERSION=${{ env.version }} firmware
           make IN_HOST=1 WORKDIR=$(pwd) initial_image
       - name: release
         id: create_release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,8 @@
 
 name: release
 on:
+  release:
+    types: [published]
   push:
     tags:
       - 'v*'
@@ -36,14 +38,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
       - name: build
         id: build
         run: |
           set -e
-          make IN_HOST=1 setup
-          make IN_HOST=1 bootloader
-          make IN_HOST=1 firmware
-          make IN_HOST=1 initial
+          make IN_HOST=1 WORKDIR=$(pwd) setup
+          make IN_HOST=1 WORKDIR=$(pwd) bootloader
+          make IN_HOST=1 WORKDIR=$(pwd) VERSION=${{ github.ref_name }} firmware
+          make IN_HOST=1 WORKDIR=$(pwd) initial_image
       - name: release
         id: create_release
         uses: actions/create-release@v1

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,9 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+VERSION:=$(shell git describe --tags HEAD)
+RUNNER:=$(if $(IN_HOST), $(), docker compose run --rm zephyrbuilder)
+
 .PHONY: all
 all: bootloader firmware
 
@@ -30,7 +33,7 @@ clean:
 
 .PHONY: distclean
 distclean: clean
-	rm -rf build-mcuboot build bootloader modules ros_msgs tools zephyr
+	rm -rf build-mcuboot build bootloader modules ros_msgs tools zephyr out .west
 
 .PHONY: build
 build: docker-compose.yml Dockerfile
@@ -38,20 +41,31 @@ build: docker-compose.yml Dockerfile
 
 .PHONY: setup
 setup:
-	docker compose run --rm zephyrbuilder west init -l lexxpluss_apps
-
+	$(RUNNER) west init -l lexxpluss_apps
+	$(RUNNER) west update
+	$(RUNNER) west config --global zephyr.base-prefer configfile
 .PHONY: update
 update:
-	docker compose run --rm zephyrbuilder west update
+	$(RUNNER) west update
 
 .PHONY: bootloader
 bootloader:
-	docker compose run --rm zephyrbuilder west build -b lexxpluss_scb bootloader/mcuboot/boot/zephyr -d build-mcuboot -- -DBOARD_ROOT=/workdir/extra
+	$(RUNNER) west zephyr-export
+	$(RUNNER) west build -b lexxpluss_scb bootloader/mcuboot/boot/zephyr -d build-mcuboot -- -DBOARD_ROOT=/workdir/extra -DVERSION=${VERSION}
 
 .PHONY: firmware
 firmware:
-	docker compose run --rm zephyrbuilder west build -b lexxpluss_scb lexxpluss_apps -- -DBOARD_ROOT=/workdir/extra -DZEPHYR_EXTRA_MODULES=/workdir/extra
+	$(RUNNER) west zephyr-export
+	$(RUNNER) west build -b lexxpluss_scb lexxpluss_apps -- -DBOARD_ROOT=/workdir/extra -DZEPHYR_EXTRA_MODULES=/workdir/extra -DVERSION=${VERSION}
 
 .PHONY: firmware_interlock
 firmware_interlock:
-	docker compose run --rm zephyrbuilder west build -b lexxpluss_scb lexxpluss_apps -- -DENABLE_INTERLOCK=1 -DBOARD_ROOT=/workdir/extra -DZEPHYR_EXTRA_MODULES=/workdir/extra
+	$(RUNNER) west zephyr-export
+	$(RUNNER) west build -b lexxpluss_scb lexxpluss_apps -- -DENABLE_INTERLOCK=1 -DBOARD_ROOT=/workdir/extra -DZEPHYR_EXTRA_MODULES=/workdir/extra -DVERSION=${VERSION}
+
+.PHONY: initial
+initial:
+	dd if=/dev/zero bs=1k count=256 | tr "\000" "\377" > bl_with_ff.bin
+	dd if=build-mcuboot/zephyr/zephyr.bin of=bl_with_ff.bin conv=notrunc
+	cat bl_with_ff.bin build/zephyr/zephyr.signed.bin > firmware.bin
+

--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,9 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-VERSION:=$(shell git describe --tags HEAD)
-WORKDIR:=$(if $(WORKDIR), $(), workdir)
-RUNNER:=$(if $(IN_HOST), $(), docker compose run --rm zephyrbuilder)
+VERSION:=$(shell git describe --tags HEAD | cut -c2-)
+WORKDIR:=$(if $(WORKDIR),$(),workdir)
+RUNNER:=$(if $(IN_HOST),$(),docker compose run --rm zephyrbuilder)
 
 .PHONY: all
 all: bootloader firmware

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 VERSION:=$(shell git describe --tags HEAD)
+WORKDIR:=$(if $(WORKDIR), $(), workdir)
 RUNNER:=$(if $(IN_HOST), $(), docker compose run --rm zephyrbuilder)
 
 .PHONY: all
@@ -51,21 +52,20 @@ update:
 .PHONY: bootloader
 bootloader:
 	$(RUNNER) west zephyr-export
-	$(RUNNER) west build -b lexxpluss_scb bootloader/mcuboot/boot/zephyr -d build-mcuboot -- -DBOARD_ROOT=/workdir/extra -DVERSION=${VERSION}
+	$(RUNNER) west build -b lexxpluss_scb bootloader/mcuboot/boot/zephyr -d build-mcuboot -- -DBOARD_ROOT=/${WORKDIR}/extra
 
 .PHONY: firmware
 firmware:
 	$(RUNNER) west zephyr-export
-	$(RUNNER) west build -b lexxpluss_scb lexxpluss_apps -- -DBOARD_ROOT=/workdir/extra -DZEPHYR_EXTRA_MODULES=/workdir/extra -DVERSION=${VERSION}
+	$(RUNNER) west build -b lexxpluss_scb lexxpluss_apps -- -DBOARD_ROOT=/${WORKDIR}/extra -DZEPHYR_EXTRA_MODULES=/${WORKDIR}/extra -DVERSION=${VERSION}
 
 .PHONY: firmware_interlock
 firmware_interlock:
 	$(RUNNER) west zephyr-export
-	$(RUNNER) west build -b lexxpluss_scb lexxpluss_apps -- -DENABLE_INTERLOCK=1 -DBOARD_ROOT=/workdir/extra -DZEPHYR_EXTRA_MODULES=/workdir/extra -DVERSION=${VERSION}
+	$(RUNNER) west build -b lexxpluss_scb lexxpluss_apps -- -DENABLE_INTERLOCK=1 -DBOARD_ROOT=/${WORKDIR}/extra -DZEPHYR_EXTRA_MODULES=/${WORKDIR}/extra -DVERSION=${VERSION}
 
-.PHONY: initial
-initial:
+.PHONY: initial_image
+initial_image:
 	dd if=/dev/zero bs=1k count=256 | tr "\000" "\377" > bl_with_ff.bin
 	dd if=build-mcuboot/zephyr/zephyr.bin of=bl_with_ff.bin conv=notrunc
 	cat bl_with_ff.bin build/zephyr/zephyr.signed.bin > firmware.bin
-

--- a/lexxpluss_apps/CMakeLists.txt
+++ b/lexxpluss_apps/CMakeLists.txt
@@ -34,3 +34,7 @@ target_include_directories(app PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../ros_msgs)
 if(ENABLE_INTERLOCK)
     add_definitions(-DENABLE_INTERLOCK)
 endif()
+
+if(VERSION)
+    add_definitions(-DVERSION=${VERSION})
+endif()

--- a/lexxpluss_apps/src/can_controller.cpp
+++ b/lexxpluss_apps/src/can_controller.cpp
@@ -34,6 +34,16 @@
 #include "led_controller.hpp"
 #include "power_state.hpp"
 
+
+#define QUOTE(name) #name
+#define STR(macro) QUOTE(macro)
+
+#ifndef VERSION
+#  define VERSION v0.0.0-local-build  // This version must not be used for production. Only for local build.
+#endif  // VERSION
+#define VERSION_STR STR(VERSION)
+
+
 namespace lexxhard::can_controller {
 
 LOG_MODULE_REGISTER(can);
@@ -149,7 +159,7 @@ private:
     board_controller::msg_rcv_pb msg_board_to_pb{0};
     uint32_t prev_cycle_ros{0}, prev_cycle_send{0};
     bool heartbeat_timeout{false}, enable_lockdown{true};
-    static constexpr char version[]{"3.0.3"};
+    static constexpr char version[]{VERSION_STR};
 } impl;
 
 int brd_emgoff(const shell *shell, size_t argc, char **argv)


### PR DESCRIPTION
ref: [HWDEV-2324](https://lexxpluss.atlassian.net/browse/HWDEV-2324)

This PR is motivated to improve CI workflow and build tasks for easy building and releasing firmware. This PR contains follwoings.

* Add a feature to specify version in build time. This means that the version in firmware are embedded automatically by using repository tag information.
* Add a feature to assign labels to PR automatically. Assigned labels are decided by simple rule in `.github/assign-label-rules.yml`
* Add a feature to create draft release automatically.

Following are examples of specifying version feature

**specifying version from  git tag**

build log
```
$ make firmware
docker compose run --rm zephyrbuilder west zephyr-export
Openbox-Message: Unable to find a valid menu file "/var/lib/openbox/debian-menu.xml"
Xlib:  extension "DPMS" missing on display ":0".
The VNC desktop is:      d0cb0f56a2ab:0
PORT=5900
Zephyr (/workdir/zephyr/share/zephyr-package/cmake)
has been added to the user package registry in:
~/.cmake/packages/Zephyr
ZephyrUnittest (/workdir/zephyr/share/zephyrunittest-package/cmake)
has been added to the user package registry in:
~/.cmake/packages/ZephyrUnittest
docker compose run --rm zephyrbuilder west build -b lexxpluss_scb lexxpluss_apps -- -DBOARD_ROOT=/workdir/extra -DZEPHYR_EXTRA_MODULES=/workdir/extra -DVERSION=3.0.3-6-g99d0fb3    ## <------ 3.0.3-6-g99d0fb3 is specified automatically
...
```

shell log
```
uart:~$ brd info
Bumper:0 Emergency:0 SafetyLiDAR:1 Power:0
Shutdown:0 Reason:0 AutoCharge:0 ManualCharge:0
CFET:1 DFET:1 PDSG:1
V24_PG:1 VPERIPH_PG:1 VWHEEL_L_PG:1 VWHEEL_R_PG:1
STATE:1 WHEEL:1
FAN:100
ConnTemp:P 28 N 25
Lockdown:enable
Charge Connector Voltage:16.000000 Count:0 Delay:5 ChargeTempGood:0
Version:3.0.3-6-g99d0fb3
```

**specifying version manually**

build log
```
$ make VERSION=3.0.9999 firmware
docker compose run --rm zephyrbuilder west zephyr-export
Openbox-Message: Unable to find a valid menu file "/var/lib/openbox/debian-menu.xml"
Xlib:  extension "DPMS" missing on display ":0".
The VNC desktop is:      5ed6aebfb8fb:0
PORT=5900
Zephyr (/workdir/zephyr/share/zephyr-package/cmake)
has been added to the user package registry in:
~/.cmake/packages/Zephyr
ZephyrUnittest (/workdir/zephyr/share/zephyrunittest-package/cmake)
has been added to the user package registry in:
~/.cmake/packages/ZephyrUnittest
docker compose run --rm zephyrbuilder west build -b lexxpluss_scb lexxpluss_apps -- -DBOARD_ROOT=/workdir/extra -DZEPHYR_EXTRA_MODULES=/workdir/extra -DVERSION=3.0.9999
```

shell log
```
uart:~$ brd info
Bumper:0 Emergency:0 SafetyLiDAR:1 Power:0
Shutdown:0 Reason:0 AutoCharge:0 ManualCharge:0
CFET:1 DFET:1 PDSG:1
V24_PG:1 VPERIPH_PG:1 VWHEEL_L_PG:1 VWHEEL_R_PG:1
STATE:1 WHEEL:1
FAN:100
ConnTemp:P 22 N 20
Lockdown:enable
Charge Connector Voltage:14.000000 Count:0 Delay:3 ChargeTempGood:0
Version:3.0.9999
```


 

[HWDEV-2324]: https://lexxpluss.atlassian.net/browse/HWDEV-2324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ