### PR TITLE
Hwdev 2286 add init with upward dir

### DIFF
--- a/lexxpluss_apps/src/actuator_controller.cpp
+++ b/lexxpluss_apps/src/actuator_controller.cpp
@@ -671,10 +671,23 @@ public:
             k_msleep(10);
         }
     }
-    int init_location() {
+    int init_location(int8_t const directions[], size_t n) {
         LOG_INF("initialize location.");
+        if (n != ACTUATOR_NUM) {
+            LOG_WRN("invalid number of directions.");
+            return -1;
+        }
+        for (uint32_t i{0}; i < ACTUATOR_NUM; ++i) {
+            if (directions[i] != msg_control::UP && directions[i] != msg_control::DOWN) {
+                LOG_WRN("invalid direction.");
+                return -1;
+            }
+        }
+
         location_initialized = false;
-        pwm_trampoline_all(msg_control::DOWN, 100);
+        for (uint32_t i{0}; i < ACTUATOR_NUM; ++i) {
+            pwm_trampoline(i, directions[i], 100);
+        }
         bool stopped{wait_actuator_stop(30000, 100)};
         pwm_trampoline_all(msg_control::STOP);
         if (!stopped || board_controller::is_emergency()) {
@@ -686,7 +699,7 @@ public:
         location_initialized = true;
         return 0;
     }
-    int to_location(const uint8_t (&location)[ACTUATOR_NUM], const uint8_t (&power)[ACTUATOR_NUM], uint8_t (&detail)[ACTUATOR_NUM]) {
+    int to_location(const int8_t (&location)[ACTUATOR_NUM], const uint8_t (&power)[ACTUATOR_NUM], uint8_t (&detail)[ACTUATOR_NUM]) {
         LOG_INF("move location.");
         if (!location_initialized) {
             for (uint32_t i{0}; i < ACTUATOR_NUM; ++i)
@@ -814,8 +827,24 @@ int cmd_duty_rep_all(const shell *shell, size_t argc, char **argv)
 
 int cmd_init(const shell *shell, size_t argc, char **argv)
 {
+    if (argc != 1 && argc != 4) {
+        shell_error(shell, "Usage: %s %s <direction> ...\n", argv[-1], argv[0]);
+        return 1;
+    }
+
+    int8_t directions[ACTUATOR_NUM]{msg_control::DOWN, msg_control::DOWN, msg_control::DOWN};
+    for (size_t i{1}; i < argc; ++i) {
+        int8_t cur_dir = atoi(argv[i]);
+        if (cur_dir != msg_control::UP && cur_dir != msg_control::DOWN) {
+            shell_print(shell, "Invalid direction.");
+            return 1;
+        }
+
+        directions[i-1] = cur_dir;
+    }
+
     shell_print(shell, "[notice] parameter order [Center] [Left] [Right]");
-    if (impl.init_location() != 0)
+    if (impl.init_location(directions, ACTUATOR_NUM) != 0)
         shell_print(shell, "init error.");
     return 0;
 }
@@ -823,7 +852,9 @@ int cmd_init(const shell *shell, size_t argc, char **argv)
 int locate(const shell *shell, size_t argc, char **argv)
 {
     shell_print(shell, "[notice] parameter order [Center] [Left] [Right]");
-    uint8_t location[ACTUATOR_NUM]{0, 0, 0}, power[ACTUATOR_NUM]{0, 0, 0}, detail[ACTUATOR_NUM]{0, 0, 0};
+    int8_t location[ACTUATOR_NUM]{0, 0, 0};
+    uint8_t power[ACTUATOR_NUM]{0, 0, 0};
+    uint8_t detail[ACTUATOR_NUM]{0, 0, 0};
     if (argc != 3 && argc != 5 && argc != 7) {
         shell_error(shell, "Usage: %s %s <location> <power> ...\n", argv[-1], argv[0]);
         return 1;
@@ -871,12 +902,12 @@ void run(void *p1, void *p2, void *p3)
     impl.run();
 }
 
-int init_location()
+int init_location(int8_t const directions[], size_t n)
 {
-    return impl.init_location();
+    return impl.init_location(directions, n);
 }
 
-int to_location(const uint8_t (&location)[ACTUATOR_NUM], const uint8_t (&power)[ACTUATOR_NUM], uint8_t (&detail)[ACTUATOR_NUM])
+int to_location(const int8_t (&location)[ACTUATOR_NUM], const uint8_t (&power)[ACTUATOR_NUM], uint8_t (&detail)[ACTUATOR_NUM])
 {
     return impl.to_location(location, power, detail);
 }

--- a/lexxpluss_apps/src/actuator_controller.hpp
+++ b/lexxpluss_apps/src/actuator_controller.hpp
@@ -33,10 +33,10 @@ struct can_format_encoder {
     can_format_encoder(int16_t enc0,int16_t enc1,int16_t enc2) : encoder_count{enc0, enc1, enc2} {} 
     int16_t encoder_count[3]; // Left / Center / Right
     void into(uint8_t data[8]) {
-        data[0] = static_cast<uint8_t>((encoder_count[0] >> 8) & 0xff);
-        data[1] = static_cast<uint8_t>(encoder_count[0] & 0xff);
-        data[2] = static_cast<uint8_t>((encoder_count[1] >> 8) & 0xff);
-        data[3] = static_cast<uint8_t>(encoder_count[1] & 0xff);
+        data[0] = static_cast<uint8_t>((encoder_count[1] >> 8) & 0xff);
+        data[1] = static_cast<uint8_t>(encoder_count[1] & 0xff);
+        data[2] = static_cast<uint8_t>((encoder_count[0] >> 8) & 0xff);
+        data[3] = static_cast<uint8_t>(encoder_count[0] & 0xff);
         data[4] = static_cast<uint8_t>((encoder_count[2] >> 8) & 0xff);
         data[5] = static_cast<uint8_t>(encoder_count[2] & 0xff); 
     }
@@ -47,10 +47,10 @@ struct can_format_current {
     int16_t current_mv[3]; // Left / Center / Right
     int16_t connection_mv;
     void into(uint8_t data[8]) {
-        data[0] = static_cast<uint8_t>((current_mv[0] >> 8) & 0xff);
-        data[1] = static_cast<uint8_t>(current_mv[0] & 0xff);
-        data[2] = static_cast<uint8_t>((current_mv[1] >> 8) & 0xff);
-        data[3] = static_cast<uint8_t>(current_mv[1] & 0xff);
+        data[0] = static_cast<uint8_t>((current_mv[1] >> 8) & 0xff);
+        data[1] = static_cast<uint8_t>(current_mv[1] & 0xff);
+        data[2] = static_cast<uint8_t>((current_mv[0] >> 8) & 0xff);
+        data[3] = static_cast<uint8_t>(current_mv[0] & 0xff);
         data[4] = static_cast<uint8_t>((current_mv[2] >> 8) & 0xff);
         data[5] = static_cast<uint8_t>(current_mv[2] & 0xff);
         data[6] = static_cast<uint8_t>((connection_mv >> 8) & 0xff);
@@ -84,8 +84,8 @@ struct msg {
 
 void init();
 void run(void *p1, void *p2, void *p3);
-int init_location();
-int to_location(const uint8_t (&location)[3], const uint8_t (&power)[3], uint8_t (&detail)[3]);
+int init_location(int8_t const directoins[], size_t n);
+int to_location(const int8_t (&location)[3], const uint8_t (&power)[3], uint8_t (&detail)[3]);
 extern k_thread thread;
 extern k_msgq msgq, msgq_control;
 

--- a/lexxpluss_apps/src/actuator_service_controller.cpp
+++ b/lexxpluss_apps/src/actuator_service_controller.cpp
@@ -64,7 +64,7 @@ public:
 private:
     std::optional<struct msg_response> handle_request(struct  msg_request const& msg_req)
     {
-        if(msg_req.mode == service_mode::INIT_DOWN || msg_req.mode == service_mode::INIT_UP) {
+        if(msg_req.mode == service_mode::INIT) {
             return do_init_service(msg_req);
         } else if(msg_req.mode == service_mode::LOCATION) {
             return do_location_service(msg_req);
@@ -76,7 +76,12 @@ private:
 
     struct msg_response do_init_service(struct msg_request const& msg_req)
     {
-        bool const ret{actuator_controller::init_location() == 0};
+        int8_t const directions[3]{
+            msg_req.left.location,
+            msg_req.center.location,
+            msg_req.right.location
+        };
+        bool const ret{actuator_controller::init_location(directions, 3) == 0};
         return {
             .mode = msg_req.mode,
             .success = ret,
@@ -89,14 +94,14 @@ private:
 
     struct msg_response do_location_service(struct msg_request const& msg_req)
     {
-        uint8_t const location[3]{
-            msg_req.center.location,
+        int8_t const location[3]{
             msg_req.left.location,
+            msg_req.center.location,
             msg_req.right.location
         };
         uint8_t const power[3]{
-            msg_req.center.power,
             msg_req.left.power,
+            msg_req.center.power,
             msg_req.right.power
         };
         uint8_t detail[3]{0, 0, 0};

--- a/lexxpluss_apps/src/actuator_service_controller.hpp
+++ b/lexxpluss_apps/src/actuator_service_controller.hpp
@@ -29,16 +29,15 @@
 
 namespace lexxhard::actuator_service_controller {
 
-enum class service_mode: int8_t {
-    INIT_DOWN = -1,
+enum class service_mode: uint8_t {
     LOCATION = 0,
-    INIT_UP = 1,
+    INIT = 1,
 };
 
 struct msg_request {
     service_mode mode;
     struct {
-        uint8_t location;
+        int8_t location;
         uint8_t power;
     } left, center, right;
     uint8_t counter;
@@ -46,9 +45,9 @@ struct msg_request {
     static msg_request from(uint8_t data[8]) {
         return {
             .mode = static_cast<service_mode>(data[0]),
-            .left = {data[1], data[4]},
-            .center = {data[2], data[5]},
-            .right = {data[3], data[6]},
+            .left = {static_cast<int8_t>(data[1]), data[4]},
+            .center = {static_cast<int8_t>(data[2]), data[5]},
+            .right = {static_cast<int8_t>(data[3]), data[6]},
             .counter = data[7]
         };
     }

--- a/lexxpluss_apps/src/board_controller.cpp
+++ b/lexxpluss_apps/src/board_controller.cpp
@@ -1383,10 +1383,7 @@ private:
             } else if (esw.is_asserted()) {
                 LOG_DBG("emergency switch asserted\n");
                 set_new_state(POWER_STATE::SUSPEND);
-            } else if (sl.is_asserted()) {
-                LOG_DBG("safety lidar asserted\n");
-                set_new_state(POWER_STATE::SUSPEND);
-            } else if (!esw.is_asserted() && !mbd.emergency_stop_from_ros() && mbd.is_ready()) {
+            } else if (!esw.is_asserted() && !mbd.emergency_stop_from_ros() && mbd.is_ready() && !sl.is_asserted()) {
                 LOG_DBG("not emergency and heartbeat OK\n");
                 set_new_state(POWER_STATE::NORMAL);
             } else if (mc.is_plugged()) {

--- a/lexxpluss_apps/src/led_controller.cpp
+++ b/lexxpluss_apps/src/led_controller.cpp
@@ -49,14 +49,20 @@ public:
     bool get_message(msg &output) {
         bool updated{false};
         if (msg message_new; k_msgq_get(&msgq, &message_new, K_MSEC(DELAY_MS)) == 0) {
-            if (message.interrupt_ms > 0) {
+            if (message.priority < message_new.priority) {
+                LOG_INF("interrupted pattern %u %ums %dpri", message_new.pattern, message_new.interrupt_ms, message_new.priority);
+                message_interrupted = message;
+                cycle_interrupted = k_cycle_get_32();
+                message = message_new;
+                updated = true;
+            } else if (message.interrupt_ms > 0) {
                 if (message_new.interrupt_ms == 0) {
                     message_interrupted = message_new;
                 }
             } else {
                 if (is_new_message(message_new)) {
                     if (message_new.interrupt_ms > 0) {
-                        LOG_INF("interrupted pattern %u %ums", message_new.pattern, message_new.interrupt_ms);
+                        LOG_INF("interrupted pattern %u %ums %dpri", message_new.pattern, message_new.interrupt_ms, message_new.priority);
                         message_interrupted = message;
                         cycle_interrupted = k_cycle_get_32();
                     }

--- a/lexxpluss_apps/src/led_controller.hpp
+++ b/lexxpluss_apps/src/led_controller.hpp
@@ -39,8 +39,8 @@ struct can_format {
 
 struct msg {
     msg() : pattern(NONE), interrupt_ms(0) {}
-    msg(uint32_t pattern, uint32_t interrupt_ms) :
-        pattern(pattern), interrupt_ms(interrupt_ms) {}
+    msg(uint32_t pattern, uint32_t interrupt_ms, uint8_t priority=0) :
+        pattern(pattern), interrupt_ms(interrupt_ms), priority(priority) {}
     msg(can_format frame) : pattern(frame.pattern), cpm(frame.count_per_minutes), rgb{frame.rgb[0],frame.rgb[1],frame.rgb[2]} {}
 
     msg(const char *str) {
@@ -104,6 +104,7 @@ struct msg {
     uint8_t pattern{NONE};
     uint32_t interrupt_ms{0}, cpm{0};
     uint8_t rgb[3]{0, 0, 0};
+    uint8_t priority{0};
     static constexpr uint8_t NONE{0};
     static constexpr uint8_t EMERGENCY_STOP{1};
     static constexpr uint8_t AMR_MODE{2};


### PR DESCRIPTION
ref: [HWDEV-2286](https://lexxpluss.atlassian.net/browse/HWDEV-2286)

This PR is motivated to add new initialization mode. This new mode sets the most extended lod position as origin. So encoder values are negative in this mode. To achieve this requirements, this PR contains following modifications.

* Specify direction to actuator initialization functions. If you specify -1, the actuator is initialized with minimum lod position and vice verse.
* Change the type of location from uint8_t to int8_t to express negative value. By this modification, the maximum position we can specify is decreased from 255[mm] to 127[mm]. But it it enough in our use-case.
*  The order of encoder value is changed. we may have a bug about it.

[HWDEV-2286]: https://lexxpluss.atlassian.net/browse/HWDEV-2286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ