### PR TITLE
Hwdev 2240 feat add tug encoder configuration feature

### DIFF
--- a/lexxpluss_apps/src/tug_encoder_controller.cpp
+++ b/lexxpluss_apps/src/tug_encoder_controller.cpp
@@ -23,6 +23,8 @@
  * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <optional>
+#include <string>
 
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
@@ -31,6 +33,10 @@
 #include <zephyr/shell/shell.h>
 #include <zephyr/drivers/i2c.h>
 #include "tug_encoder_controller.hpp"
+
+namespace {
+    std::optional<std::string> active_token{std::nullopt};
+}
 
 namespace lexxhard::tug_encoder_controller { 
 
@@ -41,6 +47,7 @@ char __aligned(4) msgq_buffer[8 * sizeof (msg)];
 class tug_encoder_controller_impl {
 public:
     int init() {
+        k_mutex_init(&mut);
         k_msgq_init(&msgq, msgq_buffer, sizeof (msg), 8);
 
         dev = DEVICE_DT_GET(DT_NODELABEL(i2c2));
@@ -65,7 +72,11 @@ public:
         }
 
         while (true) {
-            fetch_angle();
+            auto const ret{fetch_encoder_value()};
+            if (!ret) {
+                LOG_ERR("Failed to fetch encoder value");
+            }
+
             while (k_msgq_put(&msgq, &message, K_NO_WAIT) != 0)
                 k_msgq_purge(&msgq);
             k_msleep(1);
@@ -73,9 +84,50 @@ public:
     }
 
     void tug_encoder_info(const shell *shell) const {
-        float const angle_deg = message.angle * 360.0f / 4096.0f;
+        float const angle_deg{message.angle * 360.0f / 4096.0f};
+        int8_t const burn_count{get_burn_count().value_or(-1)};
         shell_print(shell, "Angle: %f[deg]", angle_deg);
-        shell_print(shell, "Connected: %d", is_tug_connected);
+        shell_print(shell, "TUG connected: %d", is_tug_connected);
+        shell_print(shell, "Magnet detected: %d", is_magnet_detected());
+        shell_print(shell, "Burn count: %d", burn_count);
+    }
+
+    bool burn_angle()  {
+        if (!is_tug_connected) {
+            LOG_ERR("TUG Encoder not found");
+            return false;
+        }
+
+        if (!is_magnet_detected()) {
+            LOG_ERR("Magnet not detected");
+            return false;
+        }
+
+        // burn angle
+        std::optional<uint16_t> const angle{get_angle()};
+        if (!angle.has_value()) {
+            LOG_ERR("Failed to get angle");
+            return false;
+        }
+
+        if (!write_zpos(angle.value())) {
+            LOG_ERR("Failed to write angle to AS5600_REG_ZPOS");
+            return false;
+        }
+        k_msleep(3);
+
+        if (!write_mpos(angle.value())) {
+            LOG_ERR("Failed to write angle to AS5600_REG_MPOS");
+            return false;
+        }
+        k_msleep(3);
+
+        if (!write_burn_sequence()) {
+            LOG_ERR("Failed to write burn sequence");
+            return false;
+        }
+
+        return true;
     }
 
 private:
@@ -92,27 +144,133 @@ private:
         return false;
     }
 
-    void fetch_angle() {
+    bool store_angle(uint16_t angle ) {
+        // message.angle is used as the bias angle to burn
+        // So message.angle is read by another thread (shell command)
+        // This means that message.angle should be updated atomically
+        if (k_mutex_lock(&mut, K_MSEC(100)) == 0) {
+            message.angle = angle;
+            k_mutex_unlock(&mut);
+        } else {
+            LOG_WRN("Cannot lock to store angle");
+            return false;
+        }
+
+        return true;
+    }
+
+    std::optional<uint16_t> get_angle() {
+        uint16_t angle;
+        if (k_mutex_lock(&mut, K_MSEC(100)) == 0) {
+            angle = message.angle;
+            k_mutex_unlock(&mut);
+        } else {
+            LOG_WRN("Cannot lock to read angle");
+            return std::nullopt;
+        }
+
+        return angle;
+    }
+
+    bool fetch_encoder_value() {
         uint8_t angle_h;
         if (i2c_reg_read_byte(dev, AS5600_ADDR, AS5600_REG_ANGLE_H, &angle_h)) {
-            LOG_ERR("Failed to read angle high byte\n");
-            return;
+            LOG_WRN("Failed to read angle high byte");
+            return false;
         }
         uint8_t angle_l;
         if (i2c_reg_read_byte(dev, AS5600_ADDR, AS5600_REG_ANGLE_L, &angle_l)) {
-            LOG_ERR("Failed to read angle low byte\n");
-            return;
+            LOG_WRN("Failed to read angle low byte");
+            return false;
         }
-    
-        message.angle = (static_cast<uint16_t>(angle_h) << 8) | angle_l;
+
+        auto const angle = (static_cast<uint16_t>(angle_h) << 8) | angle_l;
+        return store_angle(angle);
     }
+
+    bool is_magnet_detected() const{
+        uint8_t status;
+        if (i2c_reg_read_byte(dev, AS5600_ADDR, AS5600_REG_STATUS, &status)) {
+            LOG_WRN("Failed to read status");
+            return false;
+        }
+
+        return (status & 0x20) != 0;
+    }
+
+    std::optional<uint8_t> get_burn_count() const {
+        uint8_t burn_count;
+        if (i2c_reg_read_byte(dev, AS5600_ADDR, AS5600_REG_ZMCO, &burn_count)) {
+            LOG_WRN("Failed to read burn count");
+            return std::nullopt;
+        }
+
+        return burn_count;
+    }
+
+    bool write_zpos(uint16_t angle) {
+        uint8_t angle_h = (angle >> 8) & 0xFF;
+        uint8_t angle_l = angle & 0xFF;
+        if (i2c_reg_write_byte(dev, AS5600_ADDR, AS5600_REG_ZPOS_H, angle_h)) {
+            LOG_WRN("Failed to write angle to AS5600_REG_ZPOS_H");
+            return false;
+        }
+        if (i2c_reg_write_byte(dev, AS5600_ADDR, AS5600_REG_ZPOS_L, angle_l)) {
+            LOG_WRN("Failed to write angle to AS5600_REG_ZPOS_L");
+            return false;
+        }
+
+        return true;
+    }
+
+    bool write_mpos(uint16_t angle) {
+        uint8_t angle_h = (angle >> 8) & 0xFF;
+        uint8_t angle_l = angle & 0xFF;
+
+        if (i2c_reg_write_byte(dev, AS5600_ADDR, AS5600_REG_MPOS_H, angle_h)) {
+            LOG_WRN("Failed to write angle to AS5600_REG_MPOS_H");
+            return false;
+        }
+        if (i2c_reg_write_byte(dev, AS5600_ADDR, AS5600_REG_MPOS_L, angle_l)) {
+            LOG_WRN("Failed to write angle to AS5600_REG_MPOS_L");
+            return false;
+        }
+
+        return true;
+    }
+
+    bool write_burn_sequence() {
+        if (i2c_reg_write_byte(dev, AS5600_ADDR, AS5600_REG_BURN, 0x01)) {
+            LOG_WRN("Failed to write 0x01 to AS5600_REG_BURN");
+            return false;
+        }
+        if (i2c_reg_write_byte(dev, AS5600_ADDR, AS5600_REG_BURN, 0x11)) {
+            LOG_WRN("Failed to write 0x11 to AS5600_REG_BURN");
+            return false;
+        }
+        if (i2c_reg_write_byte(dev, AS5600_ADDR, AS5600_REG_BURN, 0x10)) {
+            LOG_WRN("Failed to write 0x10 to AS5600_REG_BURN");
+            return false;
+        }
+
+        return true;
+    }
+
     msg message;
     const device *dev{nullptr};
     bool is_tug_connected{false};
+    struct k_mutex mut;
 
     static constexpr uint8_t AS5600_ADDR{0x36};
+    static constexpr uint8_t AS5600_REG_ZMCO{0x00};
+    static constexpr uint8_t AS5600_REG_ZPOS_H{0x01};
+    static constexpr uint8_t AS5600_REG_ZPOS_L{0x02};
+    static constexpr uint8_t AS5600_REG_MPOS_H{0x03};
+    static constexpr uint8_t AS5600_REG_MPOS_L{0x04};
+    static constexpr uint8_t AS5600_REG_STATUS{0x0B};
     static constexpr uint8_t AS5600_REG_ANGLE_H{0x0E};
     static constexpr uint8_t AS5600_REG_ANGLE_L{0x0F};
+    static constexpr uint8_t AS5600_REG_BURN{0xFF};
     static constexpr uint32_t DETECTION_RETRY_COUNT{10};
 } impl;
 
@@ -122,9 +280,53 @@ int tug_encoder_info(const shell *shell, size_t argc, char **argv)
     return 0;
 }
 
+int tug_encoder_token(const shell *shell, size_t argc, char **argv)
+{
+    static constexpr const char* hex_ascii_table{"0123456789abcdef"};
+
+    // generate token by current cycle of lower 16 bits
+    uint32_t const cur_cycle{k_cycle_get_32()};
+    active_token.emplace({
+        hex_ascii_table[(cur_cycle >> 0) & 0xF],
+        hex_ascii_table[(cur_cycle >> 4) & 0xF],
+        hex_ascii_table[(cur_cycle >> 8) & 0xF],
+        hex_ascii_table[(cur_cycle >> 12) & 0xF],
+    });
+    shell_print(shell, "Token: %s", active_token.value().c_str());
+    return 0;
+}
+
+int tug_encoder_burn(const shell *shell, size_t argc, char **argv)
+{
+    if (!active_token.has_value()) {
+        shell_print(shell, "No token available");
+        return 0;
+    }
+
+    if (argc != 2) {
+        shell_print(shell, "Usage: burn <token>");
+        return 0;
+    }
+
+    if (active_token.value() != argv[1]) {
+        shell_print(shell, "Invalid token");
+        return 0;
+    }
+    active_token.reset();
+
+    auto const ret{impl.burn_angle()};
+    if (!ret) {
+        shell_print(shell, "Failed to burn angle");
+        return 0;
+    }
+
+    return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_tug_encoder,
     SHELL_CMD(info, NULL, "TUG Encoder information", tug_encoder_info),
-    SHELL_SUBCMD_SET_END
+    SHELL_CMD(token, NULL, "Generate new token for burning angle", tug_encoder_token),
+    SHELL_CMD(burn, NULL, "Burn angle", tug_encoder_burn),
 );
 SHELL_CMD_REGISTER(tug_encoder, &sub_tug_encoder, "TUG Encoder commands", NULL);
 

--- a/lexxpluss_apps/src/tug_encoder_controller.cpp
+++ b/lexxpluss_apps/src/tug_encoder_controller.cpp
@@ -90,6 +90,14 @@ public:
         shell_print(shell, "TUG connected: %d", is_tug_connected);
         shell_print(shell, "Magnet detected: %d", is_magnet_detected());
         shell_print(shell, "Burn count: %d", burn_count);
+
+	if (burn_count == 0) {
+            shell_print(shell, "");
+            shell_print(shell, "***********************************************");
+            shell_print(shell, " CAUTION!! This tug encoder is not caliblated. ");
+            shell_print(shell, "***********************************************");
+            shell_print(shell, "");
+	}
     }
 
     bool burn_angle()  {
@@ -313,6 +321,7 @@ int tug_encoder_burn(const shell *shell, size_t argc, char **argv)
         return 0;
     }
     active_token.reset();
+    shell_print(shell, "Accept valid token and invalidate it.");
 
     auto const ret{impl.burn_angle()};
     if (!ret) {
@@ -320,6 +329,7 @@ int tug_encoder_burn(const shell *shell, size_t argc, char **argv)
         return 0;
     }
 
+    shell_print(shell, "Completed to burn angle");
     return 0;
 }
 
@@ -327,6 +337,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub_tug_encoder,
     SHELL_CMD(info, NULL, "TUG Encoder information", tug_encoder_info),
     SHELL_CMD(token, NULL, "Generate new token for burning angle", tug_encoder_token),
     SHELL_CMD(burn, NULL, "Burn angle", tug_encoder_burn),
+    SHELL_SUBCMD_SET_END
 );
 SHELL_CMD_REGISTER(tug_encoder, &sub_tug_encoder, "TUG Encoder commands", NULL);
 

--- a/lexxpluss_apps/src/tug_encoder_controller.cpp
+++ b/lexxpluss_apps/src/tug_encoder_controller.cpp
@@ -47,7 +47,6 @@ char __aligned(4) msgq_buffer[8 * sizeof (msg)];
 class tug_encoder_controller_impl {
 public:
     int init() {
-        k_mutex_init(&mut);
         k_msgq_init(&msgq, msgq_buffer, sizeof (msg), 8);
 
         dev = DEVICE_DT_GET(DT_NODELABEL(i2c2));
@@ -72,8 +71,7 @@ public:
         }
 
         while (true) {
-            auto const ret{fetch_encoder_value()};
-            if (!ret) {
+            if (!fetch_encoder_value()) {
                 LOG_ERR("Failed to fetch encoder value");
             }
 
@@ -85,19 +83,25 @@ public:
 
     void tug_encoder_info(const shell *shell) const {
         float const angle_deg{message.angle * 360.0f / 4096.0f};
-        int8_t const burn_count{get_burn_count().value_or(-1)};
+        int const burn_count{get_burn_count().value_or(-1)};
+        int const raw_angle{get_raw_angle().value_or(-1)};
+        int const zpos{get_zero_angle().value_or(-1)};
+        int const mpos{get_max_angle().value_or(-1)};
         shell_print(shell, "Angle: %f[deg]", angle_deg);
         shell_print(shell, "TUG connected: %d", is_tug_connected);
         shell_print(shell, "Magnet detected: %d", is_magnet_detected());
+        shell_print(shell, "Raw Angle: %d", raw_angle);
         shell_print(shell, "Burn count: %d", burn_count);
+        shell_print(shell, "ZPOS: %d", zpos);
+        shell_print(shell, "MPOS: %d", mpos);
 
-	if (burn_count == 0) {
+        if (burn_count == 0) {
             shell_print(shell, "");
             shell_print(shell, "***********************************************");
             shell_print(shell, " CAUTION!! This tug encoder is not caliblated. ");
             shell_print(shell, "***********************************************");
             shell_print(shell, "");
-	}
+        }
     }
 
     bool burn_angle()  {
@@ -111,20 +115,19 @@ public:
             return false;
         }
 
-        // burn angle
-        std::optional<uint16_t> const angle{get_angle()};
-        if (!angle.has_value()) {
-            LOG_ERR("Failed to get angle");
+	    auto const raw_angle{get_raw_angle()};
+        if (!raw_angle.has_value()) {
+            LOG_ERR("Failed to read raw angle");
             return false;
         }
 
-        if (!write_zpos(angle.value())) {
+        if (!write_zero_angle(raw_angle.value())) {
             LOG_ERR("Failed to write angle to AS5600_REG_ZPOS");
             return false;
         }
         k_msleep(3);
 
-        if (!write_mpos(angle.value())) {
+        if (!write_max_angle(raw_angle.value())) {
             LOG_ERR("Failed to write angle to AS5600_REG_MPOS");
             return false;
         }
@@ -152,34 +155,6 @@ private:
         return false;
     }
 
-    bool store_angle(uint16_t angle ) {
-        // message.angle is used as the bias angle to burn
-        // So message.angle is read by another thread (shell command)
-        // This means that message.angle should be updated atomically
-        if (k_mutex_lock(&mut, K_MSEC(100)) == 0) {
-            message.angle = angle;
-            k_mutex_unlock(&mut);
-        } else {
-            LOG_WRN("Cannot lock to store angle");
-            return false;
-        }
-
-        return true;
-    }
-
-    std::optional<uint16_t> get_angle() {
-        uint16_t angle;
-        if (k_mutex_lock(&mut, K_MSEC(100)) == 0) {
-            angle = message.angle;
-            k_mutex_unlock(&mut);
-        } else {
-            LOG_WRN("Cannot lock to read angle");
-            return std::nullopt;
-        }
-
-        return angle;
-    }
-
     bool fetch_encoder_value() {
         uint8_t angle_h;
         if (i2c_reg_read_byte(dev, AS5600_ADDR, AS5600_REG_ANGLE_H, &angle_h)) {
@@ -192,8 +167,8 @@ private:
             return false;
         }
 
-        auto const angle = (static_cast<uint16_t>(angle_h) << 8) | angle_l;
-        return store_angle(angle);
+        message.angle = (static_cast<uint16_t>(angle_h) << 8) | angle_l;
+        return true;
     }
 
     bool is_magnet_detected() const{
@@ -209,20 +184,68 @@ private:
     std::optional<uint8_t> get_burn_count() const {
         uint8_t burn_count;
         if (i2c_reg_read_byte(dev, AS5600_ADDR, AS5600_REG_ZMCO, &burn_count)) {
-            LOG_WRN("Failed to read burn count");
+            LOG_WRN("Failed to read ZMCO");
             return std::nullopt;
         }
 
         return burn_count;
     }
 
-    bool write_zpos(uint16_t angle) {
+    std::optional<uint16_t> get_zero_angle() const {
+        uint8_t angle_h;
+        if (i2c_reg_read_byte(dev, AS5600_ADDR, AS5600_REG_ZPOS_H, &angle_h)) {
+            LOG_WRN("Failed to read AS5600_REG_ZPOS_H");
+            return 0;
+        }
+
+        uint8_t angle_l;
+        if (i2c_reg_read_byte(dev, AS5600_ADDR, AS5600_REG_ZPOS_L, &angle_l)) {
+            LOG_WRN("Failed to read AS5600_REG_ZPOS_L");
+            return 0;
+        }
+
+        return (angle_h <<8) | angle_l;
+    }
+
+    std::optional<uint16_t> get_max_angle() const {
+        uint8_t angle_h;
+        if (i2c_reg_read_byte(dev, AS5600_ADDR, AS5600_REG_MPOS_H, &angle_h)) {
+            LOG_WRN("Failed to read AS5600_REG_MPOS_H");
+            return 0;
+        }
+
+        uint8_t angle_l;
+        if (i2c_reg_read_byte(dev, AS5600_ADDR, AS5600_REG_MPOS_L, &angle_l)) {
+            LOG_WRN("Failed to read AS5600_REG_MPOS_L");
+            return 0;
+        }
+
+        return (angle_h <<8) | angle_l;
+    }
+
+    std::optional<uint16_t> get_raw_angle() const {
+        uint8_t angle_h;
+        if (i2c_reg_read_byte(dev, AS5600_ADDR, AS5600_REG_RAW_ANGLE_H, &angle_h)) {
+            LOG_WRN("Failed to read AS5600_REG_RAW_ANGLE_H");
+            return 0;
+        }
+
+        uint8_t angle_l;
+        if (i2c_reg_read_byte(dev, AS5600_ADDR, AS5600_REG_RAW_ANGLE_L, &angle_l)) {
+            LOG_WRN("Failed to read AS5600_REG_RAW_ANGLE_L");
+            return 0;
+        }
+
+        return (angle_h <<8) | angle_l;
+    }
+
+    bool write_zero_angle(uint16_t angle) {
         uint8_t angle_h = (angle >> 8) & 0xFF;
-        uint8_t angle_l = angle & 0xFF;
         if (i2c_reg_write_byte(dev, AS5600_ADDR, AS5600_REG_ZPOS_H, angle_h)) {
             LOG_WRN("Failed to write angle to AS5600_REG_ZPOS_H");
             return false;
         }
+        uint8_t angle_l = angle & 0xFF;
         if (i2c_reg_write_byte(dev, AS5600_ADDR, AS5600_REG_ZPOS_L, angle_l)) {
             LOG_WRN("Failed to write angle to AS5600_REG_ZPOS_L");
             return false;
@@ -231,14 +254,14 @@ private:
         return true;
     }
 
-    bool write_mpos(uint16_t angle) {
+    bool write_max_angle(uint16_t angle) {
         uint8_t angle_h = (angle >> 8) & 0xFF;
-        uint8_t angle_l = angle & 0xFF;
-
         if (i2c_reg_write_byte(dev, AS5600_ADDR, AS5600_REG_MPOS_H, angle_h)) {
             LOG_WRN("Failed to write angle to AS5600_REG_MPOS_H");
             return false;
         }
+
+        uint8_t angle_l = angle & 0xFF;
         if (i2c_reg_write_byte(dev, AS5600_ADDR, AS5600_REG_MPOS_L, angle_l)) {
             LOG_WRN("Failed to write angle to AS5600_REG_MPOS_L");
             return false;
@@ -248,6 +271,12 @@ private:
     }
 
     bool write_burn_sequence() {
+        if (i2c_reg_write_byte(dev, AS5600_ADDR, AS5600_REG_BURN, 0x80)) {
+            LOG_WRN("Failed to write 0x01 to AS5600_REG_BURN");
+            return false;
+        }
+        k_msleep(5);
+
         if (i2c_reg_write_byte(dev, AS5600_ADDR, AS5600_REG_BURN, 0x01)) {
             LOG_WRN("Failed to write 0x01 to AS5600_REG_BURN");
             return false;
@@ -260,6 +289,7 @@ private:
             LOG_WRN("Failed to write 0x10 to AS5600_REG_BURN");
             return false;
         }
+        k_msleep(5);
 
         return true;
     }
@@ -267,7 +297,6 @@ private:
     msg message;
     const device *dev{nullptr};
     bool is_tug_connected{false};
-    struct k_mutex mut;
 
     static constexpr uint8_t AS5600_ADDR{0x36};
     static constexpr uint8_t AS5600_REG_ZMCO{0x00};
@@ -276,6 +305,8 @@ private:
     static constexpr uint8_t AS5600_REG_MPOS_H{0x03};
     static constexpr uint8_t AS5600_REG_MPOS_L{0x04};
     static constexpr uint8_t AS5600_REG_STATUS{0x0B};
+    static constexpr uint8_t AS5600_REG_RAW_ANGLE_H{0x0C};
+    static constexpr uint8_t AS5600_REG_RAW_ANGLE_L{0x0D};
     static constexpr uint8_t AS5600_REG_ANGLE_H{0x0E};
     static constexpr uint8_t AS5600_REG_ANGLE_L{0x0F};
     static constexpr uint8_t AS5600_REG_BURN{0xFF};

--- a/lexxpluss_apps/src/tug_encoder_controller.cpp
+++ b/lexxpluss_apps/src/tug_encoder_controller.cpp
@@ -115,7 +115,7 @@ public:
             return false;
         }
 
-	    auto const raw_angle{get_raw_angle()};
+        auto const raw_angle{get_raw_angle()};
         if (!raw_angle.has_value()) {
             LOG_ERR("Failed to read raw angle");
             return false;


### PR DESCRIPTION
ref: [HWDEV-2240](https://lexxpluss.atlassian.net/browse/HWDEV-2240)

This PR is motivated to add a feature of burning origin angle to AS5600. This PR contains followings.

* Add a sub command to generate token which is used for burning angle
* Add a sub command to burn origin angle
* Improve info sub command to show magnet detected and the count of burning

The results of this PR are followings.

initial status
```
uart:~$ tug_encoder info
Angle: 320.888672[deg]
TUG connected: 1
Magnet detected: 0
Raw Angle: 4090
Burn count: 2
ZPOS: 42
MPOS: 42
```

detect magnet
```
uart:~$ tug_encoder info
Angle: 281.513672[deg]
TUG connected: 1
Magnet detected: 1
Raw Angle: 3244
Burn count: 2
ZPOS: 42
MPOS: 42
```

generate token
```
uart:~$ tug_encoder token
Token: 3b25
```

burn raw angle as zpos and mpos with wrong token
```
uart:~$ tug_encoder burn abc
Invalid token
```

burn raw angle as zpos and mpos with valid token
```
uart:~$ tug_encoder burn 3b25
Accept valid token and invalidate it.
Completed to burn angle
```

check result
```
uart:~$ tug_encoder info
Angle: 359.912109[deg]
TUG connected: 1
Magnet detected: 1
Raw Angle: 3244
Burn count: 3
ZPOS: 3244
MPOS: 3244
```

[HWDEV-2240]: https://lexxpluss.atlassian.net/browse/HWDEV-2240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ