### PR TITLE
Hwdev 2398 feat improve encoder count precision

### DIFF
--- a/lexxpluss_apps/src/actuator_controller.cpp
+++ b/lexxpluss_apps/src/actuator_controller.cpp
@@ -152,12 +152,12 @@ public:
             dev = GPIO_DT_SPEC_GET(DT_NODELABEL(encoder_center_actuator_ch1), gpios);
             // PD12 CH1, PD13 CH2
             if (gpio_is_ready_dt(&dev)) {
-                gpio_pin_configure_dt(&dev, GPIO_INPUT | GPIO_ACTIVE_HIGH);
+                gpio_pin_configure_dt(&dev, GPIO_INPUT | GPIO_PULL_UP | GPIO_ACTIVE_HIGH);
             }
 
             dev = GPIO_DT_SPEC_GET(DT_NODELABEL(encoder_center_actuator_ch2), gpios);
             if (gpio_is_ready_dt(&dev)) {
-                gpio_pin_configure_dt(&dev, GPIO_INPUT | GPIO_ACTIVE_HIGH);
+                gpio_pin_configure_dt(&dev, GPIO_INPUT | GPIO_PULL_UP | GPIO_ACTIVE_HIGH);
             }
         
             // set callback function for center
@@ -170,12 +170,12 @@ public:
             dev = GPIO_DT_SPEC_GET(DT_NODELABEL(encoder_left_actuator_ch1), gpios);
             // PD12 CH1, PD13 CH2
             if (gpio_is_ready_dt(&dev)) {
-                gpio_pin_configure_dt(&dev, GPIO_INPUT | GPIO_ACTIVE_HIGH);
+                gpio_pin_configure_dt(&dev, GPIO_INPUT | GPIO_PULL_UP | GPIO_ACTIVE_HIGH);
             }
 
             dev = GPIO_DT_SPEC_GET(DT_NODELABEL(encoder_left_actuator_ch2), gpios);
             if (gpio_is_ready_dt(&dev)) {
-                gpio_pin_configure_dt(&dev, GPIO_INPUT | GPIO_ACTIVE_HIGH);
+                gpio_pin_configure_dt(&dev, GPIO_INPUT | GPIO_PULL_UP | GPIO_ACTIVE_HIGH);
             }
 
             // set callback function for LEFT
@@ -188,12 +188,12 @@ public:
             dev = GPIO_DT_SPEC_GET(DT_NODELABEL(encoder_right_actuator_ch1), gpios);
             // PD12 CH1, PD13 CH2
             if (gpio_is_ready_dt(&dev)) {
-                gpio_pin_configure_dt(&dev, GPIO_INPUT | GPIO_ACTIVE_HIGH);
+                gpio_pin_configure_dt(&dev, GPIO_INPUT | GPIO_PULL_UP | GPIO_ACTIVE_HIGH);
             }
 
             dev = GPIO_DT_SPEC_GET(DT_NODELABEL(encoder_right_actuator_ch2), gpios);
             if (gpio_is_ready_dt(&dev)) {
-                gpio_pin_configure_dt(&dev, GPIO_INPUT | GPIO_ACTIVE_HIGH);
+                gpio_pin_configure_dt(&dev, GPIO_INPUT | GPIO_PULL_UP | GPIO_ACTIVE_HIGH);
             }
 
             // set callback function for RIGHT

--- a/lexxpluss_apps/src/actuator_controller.cpp
+++ b/lexxpluss_apps/src/actuator_controller.cpp
@@ -318,16 +318,15 @@ public:
         case POS::CENTER:
             // result = enc.init(TIM4); // for HW counter
             result = enc.init(pos);
-            // mm_per_pulse = 50.0f / 1054.0f; // for HW counter
-            mm_per_pulse = 50.0f / 144.0f;
+            mm_per_pulse = 50.0f / 1054.0f;
             break;
         case POS::LEFT:
             result = enc.init(pos);
-            mm_per_pulse = 50.0f / 144.0f;
+            mm_per_pulse = 50.0f / 1054.0f;
             break;
         case POS::RIGHT:
             result = enc.init(pos);
-            mm_per_pulse = 50.0f / 144.0f;
+            mm_per_pulse = 50.0f / 1054.0f;
             break;
         }
         reset_pulse();


### PR DESCRIPTION
ref [HWDEV-2398](https://lexxpluss.atlassian.net/browse/HWDEV-2398)

This PR is motivated to improve actuator encoder count precision. In the current implementation, SCB only use 1 state in the encoder output value cycle. This means that it drops other 3 state. So this PR modify codes to use these 3 state. The modifications in this PR are followings.

* Enable pull up of the actuator encoder pins
* Use prev_ch2 to handle all state
* Change  mm_per_pulse to  50.0f / 1054.0f;

This PR is tested in robot. The results of it are followings. Following are the logs of moving actuators in Tug installed AMR from minimum to maximum with 100% duty.

```
uart:~$ act info
[notice] parameter order [Center] [Left] [Right]
actuator: 0 encoder: -1 pulse current: 0 mV fail: 0 dir: 0 duty: 0
actuator: 1 encoder: 0 pulse current: 0 mV fail: 0 dir: 0 duty: 0
actuator: 2 encoder: 0 pulse current: 2 mV fail: 0 dir: 0 duty: 0
uart:~$ act duty 1 100 1 100 1 100
[notice] parameter order [Center] [Left] [Right]
[00:31:03.249,000] <wrn> actuator: Wrong encoder state: 00 -> 11
[00:31:11.335,000] <wrn> actuator: Wrong encoder state: 00 -> 11
uart:~$ act info
[notice] parameter order [Center] [Left] [Right]
actuator: 0 encoder: 1078 pulse current: 0 mV fail: 0 dir: 1 duty: 100
actuator: 1 encoder: 14283 pulse current: 2 mV fail: 0 dir: 1 duty: 100
actuator: 2 encoder: 22703 pulse current: 2 mV fail: 0 dir: 1 duty: 100
uart:~$ act duty -1 100 -1 100 -1 100
[notice] parameter order [Center] [Left] [Right]
[00:32:13.208,000] <wrn> actuator: Wrong encoder state: 10 -> 01
[00:32:13.291,000] <wrn> actuator: Wrong encoder state: 00 -> 11
[00:32:13.867,000] <wrn> actuator: Wrong encoder state: 00 -> 11
[00:32:17.314,000] <wrn> actuator: Wrong encoder state: 11 -> 00
[00:32:17.869,000] <wrn> actuator: Wrong encoder state: 01 -> 10
[00:32:19.545,000] <wrn> actuator: Wrong encoder state: 01 -> 10
uart:~$ act info
[notice] parameter order [Center] [Left] [Right]
actuator: 0 encoder: -1 pulse current: 0 mV fail: 0 dir: -1 duty: 100
actuator: 1 encoder: 10 pulse current: 0 mV fail: 0 dir: -1 duty: 100
actuator: 2 encoder: 1 pulse current: 2 mV fail: 0 dir: -1 duty: 100
uart:~$ act duty 1 100 1 100 1 100
[notice] parameter order [Center] [Left] [Right]
[00:32:47.796,000] <wrn> actuator: Wrong encoder state: 00 -> 11
[00:32:48.884,000] <wrn> actuator: Wrong encoder state: 11 -> 00
[00:32:54.275,000] <wrn> actuator: Wrong encoder state: 00 -> 11
uart:~$ act info
[notice] parameter order [Center] [Left] [Right]
actuator: 0 encoder: 1079 pulse current: 0 mV fail: 0 dir: 1 duty: 100
actuator: 1 encoder: 14278 pulse current: 0 mV fail: 0 dir: 1 duty: 100
actuator: 2 encoder: 22705 pulse current: 0 mV fail: 0 dir: 1 duty: 100
uart:~$ act duty -1 100 -1 100 -1 100
[notice] parameter order [Center] [Left] [Right]
[00:33:18.622,000] <wrn> actuator: Wrong encoder state: 01 -> 10
[00:33:19.517,000] <wrn> actuator: Wrong encoder state: 10 -> 01
[00:33:20.702,000] <wrn> actuator: Wrong encoder state: 01 -> 10
[00:33:21.969,000] <wrn> actuator: Wrong encoder state: 00 -> 11
[00:33:24.197,000] <wrn> actuator: Wrong encoder state: 00 -> 11
[00:33:25.876,000] <wrn> actuator: Wrong encoder state: 01 -> 10
uart:~$ act info
[notice] parameter order [Center] [Left] [Right]
actuator: 0 encoder: -2 pulse current: 2 mV fail: 0 dir: -1 duty: 100
actuator: 1 encoder: 8 pulse current: 6 mV fail: 0 dir: -1 duty: 100
actuator: 2 encoder: 6 pulse current: 0 mV fail: 0 dir: -1 duty: 100
```

From above results, we found that encoder values ware changed expectedly. And we can find some wrong actuator states. But they are enough less compared to  actuator values.

[HWDEV-2398]: https://lexxpluss.atlassian.net/browse/HWDEV-2398?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ