### PR TITLE
Hwdev 2399 feat use correct mm per pulse when tug connected

### DIFF
--- a/lexxpluss_apps/src/actuator_controller.cpp
+++ b/lexxpluss_apps/src/actuator_controller.cpp
@@ -36,6 +36,7 @@
 #include <cstdlib>
 #include <tuple>
 #include "actuator_controller.hpp"
+#include "tug_encoder_controller.hpp"
 #include "adc_reader.hpp"
 #include "board_controller.hpp"
 #include "common.hpp"
@@ -322,11 +323,19 @@ public:
             break;
         case POS::LEFT:
             result = enc.init(pos);
-            mm_per_pulse = 50.0f / 1054.0f;
+            if (tug_encoder_controller::is_tug_connected()) {
+                mm_per_pulse = 0.0033f;
+            } else {
+                mm_per_pulse = 50.0f / 1054.0f;
+            }
             break;
         case POS::RIGHT:
             result = enc.init(pos);
-            mm_per_pulse = 50.0f / 1054.0f;
+            if (tug_encoder_controller::is_tug_connected()) {
+                mm_per_pulse = 0.0033f;
+            } else {
+                mm_per_pulse = 50.0f / 1054.0f;
+            }
             break;
         }
         reset_pulse();

--- a/lexxpluss_apps/src/actuator_controller.cpp
+++ b/lexxpluss_apps/src/actuator_controller.cpp
@@ -613,14 +613,18 @@ public:
     int init() {
         k_msgq_init(&msgq, msgq_buffer, sizeof (msg), 8);
         k_msgq_init(&msgq_control, msgq_control_buffer, sizeof (msg_control), 8);
-        if (act[0].init(POS::CENTER) != 0 ||
-            act[1].init(POS::LEFT) != 0 ||
-            act[2].init(POS::RIGHT) != 0)
-            return -1;
         return 0;
     }
 
     void run() {
+        if (act[0].init(POS::CENTER) != 0 ||
+            act[1].init(POS::LEFT) != 0 ||
+            act[2].init(POS::RIGHT) != 0)
+        {
+            LOG_ERR("actuator init failed.");
+            return;
+        }
+
         // Enable Pin, Reset Functions
         gpio_dt_spec dev_enable = GET_GPIO(ps_lift_actuator);
         if (gpio_is_ready_dt(&dev_enable))

--- a/lexxpluss_apps/src/actuator_controller.cpp
+++ b/lexxpluss_apps/src/actuator_controller.cpp
@@ -36,10 +36,10 @@
 #include <cstdlib>
 #include <tuple>
 #include "actuator_controller.hpp"
-#include "tug_encoder_controller.hpp"
 #include "adc_reader.hpp"
 #include "board_controller.hpp"
 #include "common.hpp"
+#include "tug_encoder_controller.hpp"
 
 // for HW counter
 // extern "C" void HAL_TIM_Encoder_MspInit(TIM_HandleTypeDef *htim_encoder)

--- a/lexxpluss_apps/src/tug_encoder_controller.cpp
+++ b/lexxpluss_apps/src/tug_encoder_controller.cpp
@@ -307,7 +307,7 @@ private:
 
     msg message;
     const device *dev{nullptr};
-    std::optional<bool> is_tug_connected_cache{false};
+    std::optional<bool> is_tug_connected_cache{std::nullopt};
 
     static constexpr uint8_t AS5600_ADDR{0x36};
     static constexpr uint8_t AS5600_REG_ZMCO{0x00};

--- a/lexxpluss_apps/src/tug_encoder_controller.cpp
+++ b/lexxpluss_apps/src/tug_encoder_controller.cpp
@@ -36,6 +36,10 @@
 
 namespace {
     std::optional<std::string> active_token{std::nullopt};
+    template<typename T>
+    int value_or_minus_one(std::optional<T> value) {
+        return value.has_value() ? static_cast<int>(value.value()) : -1;
+    }
 }
 
 namespace lexxhard::tug_encoder_controller { 
@@ -82,10 +86,10 @@ public:
 
     void tug_encoder_info(const shell *shell) {
         float const angle_deg{message.angle * 360.0f / 4096.0f};
-        int const burn_count{get_burn_count().value_or(-1)};
-        int const raw_angle{get_raw_angle().value_or(-1)};
-        int const zpos{get_zero_angle().value_or(-1)};
-        int const mpos{get_max_angle().value_or(-1)};
+        int const burn_count{value_or_minus_one(get_burn_count())};
+        int const raw_angle{value_or_minus_one(get_raw_angle())};
+        int const zpos{value_or_minus_one(get_zero_angle())};
+        int const mpos{value_or_minus_one(get_max_angle())};
         shell_print(shell, "Angle: %f[deg]", static_cast<double>(angle_deg));
         shell_print(shell, "TUG connected: %d", is_tug_connected());
         shell_print(shell, "Magnet detected: %d", is_magnet_detected());

--- a/lexxpluss_apps/src/tug_encoder_controller.cpp
+++ b/lexxpluss_apps/src/tug_encoder_controller.cpp
@@ -212,13 +212,13 @@ private:
         uint8_t angle_h;
         if (i2c_reg_read_byte(dev, AS5600_ADDR, AS5600_REG_ZPOS_H, &angle_h)) {
             LOG_WRN("Failed to read AS5600_REG_ZPOS_H");
-            return 0;
+            return std::nullopt;
         }
 
         uint8_t angle_l;
         if (i2c_reg_read_byte(dev, AS5600_ADDR, AS5600_REG_ZPOS_L, &angle_l)) {
             LOG_WRN("Failed to read AS5600_REG_ZPOS_L");
-            return 0;
+            return std::nullopt;
         }
 
         return (angle_h <<8) | angle_l;
@@ -228,13 +228,13 @@ private:
         uint8_t angle_h;
         if (i2c_reg_read_byte(dev, AS5600_ADDR, AS5600_REG_MPOS_H, &angle_h)) {
             LOG_WRN("Failed to read AS5600_REG_MPOS_H");
-            return 0;
+            return std::nullopt;
         }
 
         uint8_t angle_l;
         if (i2c_reg_read_byte(dev, AS5600_ADDR, AS5600_REG_MPOS_L, &angle_l)) {
             LOG_WRN("Failed to read AS5600_REG_MPOS_L");
-            return 0;
+            return std::nullopt;
         }
 
         return (angle_h <<8) | angle_l;
@@ -244,13 +244,13 @@ private:
         uint8_t angle_h;
         if (i2c_reg_read_byte(dev, AS5600_ADDR, AS5600_REG_RAW_ANGLE_H, &angle_h)) {
             LOG_WRN("Failed to read AS5600_REG_RAW_ANGLE_H");
-            return 0;
+            return std::nullopt;
         }
 
         uint8_t angle_l;
         if (i2c_reg_read_byte(dev, AS5600_ADDR, AS5600_REG_RAW_ANGLE_L, &angle_l)) {
             LOG_WRN("Failed to read AS5600_REG_RAW_ANGLE_L");
-            return 0;
+            return std::nullopt;
         }
 
         return (angle_h <<8) | angle_l;

--- a/lexxpluss_apps/src/tug_encoder_controller.hpp
+++ b/lexxpluss_apps/src/tug_encoder_controller.hpp
@@ -36,6 +36,7 @@ struct msg {
 
 void init();
 void run(void *p1, void *p2, void *p3);
+bool is_tug_connected();
 extern k_thread thread;
 extern k_msgq msgq;
 }


### PR DESCRIPTION
ref: [HWDEV-2399](https://lexxpluss.atlassian.net/browse/HWDEV-2399)

This PR is motivated to add selecting mm_per_pulse  depends on whether tug is connected or not and fix wrong error value handling in info sub command. This PR contains followings

* add a function whose name is `get_mm_per_pulse` to get suitable mm_per_pulse depends on whether tug is connected or not.
* Add displaying mm_per_sec in info sub command.
* Fix wrong value cast in info sub command, which is casting -1 into uint8_t.

This PR is tested in robots. And results are followings. 

with tug
```
uart:~$ tug_encoder info
Angle: 74.882812[deg]
TUG connected: 1
Magnet detected: 0
Raw Angle: 0
Burn count: 3
ZPOS: 3244
MPOS: 3244
uart:~$ act info
[notice] parameter order [Center] [Left] [Right]
actuator: 0 encoder: -1 pulse current: 0 mV fail: 0 dir: 0 duty: 0 mm/pulse: 0.047438
actuator: 1 encoder: -1 pulse current: 0 mV fail: 0 dir: 0 duty: 0 mm/pulse: 0.003300
actuator: 2 encoder: -1 pulse current: 0 mV fail: 0 dir: 0 duty: 0 mm/pulse: 0.003300
```

without tug
```
uart:~$ tug_encoder info
Angle: 0.000000[deg]
TUG connected: 0
Magnet detected: 0
Raw Angle: -1
Burn count: -1
ZPOS: -1
MPOS: -1
[00:00:42.334,000] <wrn> tug_encoder: Failed to read ZMCO
[00:00:42.334,000] <wrn> tug_encoder: Failed to read AS5600_REG_RAW_ANGLE_H
[00:00:42.334,000] <wrn> tug_encoder: Failed to read AS5600_REG_ZPOS_H
[00:00:42.334,000] <wrn> tug_encoder: Failed to read AS5600_REG_MPOS_H
[00:00:42.337,000] <wrn> tug_encoder: Failed to read status
uart:~$ act info
[notice] parameter order [Center] [Left] [Right]
actuator: 0 encoder: -1 pulse current: 2 mV fail: 0 dir: 0 duty: 0 mm/pulse: 0.047438
actuator: 1 encoder: -1 pulse current: 0 mV fail: 0 dir: 0 duty: 0 mm/pulse: 0.047438
actuator: 2 encoder: -1 pulse current: 2 mV fail: 0 dir: 0 duty: 0 mm/pulse: 0.047438
```

[HWDEV-2399]: https://lexxpluss.atlassian.net/browse/HWDEV-2399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ