### PR TITLE
HWDEV-2428 use usart1 as default

### DIFF
--- a/extra/boards/arm/lexxpluss_scb/lexxpluss_scb.dts
+++ b/extra/boards/arm/lexxpluss_scb/lexxpluss_scb.dts
@@ -35,8 +35,8 @@
 
 	chosen {
 		zephyr,code-partition = &slot0_partition;
-		zephyr,console = &usart2;
-		zephyr,shell-uart = &usart2;
+		zephyr,console = &usart1;
+		zephyr,shell-uart = &usart1;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,dtcm = &dtcm;


### PR DESCRIPTION
ref: [HWDEV-2428](https://lexxpluss.atlassian.net/browse/HWDEV-2428)

This PR is motivated to use usart1 as default to avoid HW issue.

[HWDEV-2428]: https://lexxpluss.atlassian.net/browse/HWDEV-2428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ