### PR TITLE
AMRSW-1112 send state is emergency state or not

### DIFF
--- a/lexxpluss_apps/src/board_controller.cpp
+++ b/lexxpluss_apps/src/board_controller.cpp
@@ -1278,13 +1278,13 @@ public:
         if (state != POWER_STATE::OFF) {
             rtn = esw.is_asserted() ||
                bsw.is_asserted() ||
-               state == POWER_STATE::SUSPEND ||
-               state == POWER_STATE::RESUME_WAIT ||
                mbd.emergency_stop_from_ros() ||
-               sl.is_asserted();
+               sl.is_asserted() ||
+               is_emergency_state();
         }
         return rtn;
     }
+
 private:
     static void static_poll_100ms_callback(struct k_timer *timer_id) {
         auto* instance = static_cast<state_controller*>(k_timer_user_data_get(timer_id));
@@ -1759,7 +1759,7 @@ private:
         board2ros.auto_charging_status = ac.is_docked();
         board2ros.shutdown_reason = static_cast<uint32_t>(shutdown_reason);
         board2ros.wait_shutdown_state = state == POWER_STATE::OFF_WAIT || state == POWER_STATE::TIMEROFF;
-        board2ros.emergency_stop = is_emergency();
+        board2ros.emergency_state = is_emergency_state();
         board2ros.wheel_enable = wsw.is_enabled();
 
         bool v24{false}, v_peripheral{false}, v_wheel_motor_left{false}, v_wheel_motor_right{false};
@@ -1804,6 +1804,9 @@ private:
     }
     bool should_lockdown() const {
         return mbd.is_dead() && !esw.is_asserted();
+    }
+    bool is_emergency_state() const {
+        return state == POWER_STATE::SUSPEND || state == POWER_STATE::RESUME_WAIT;
     }
     
     power_switch psw;

--- a/lexxpluss_apps/src/can_controller.hpp
+++ b/lexxpluss_apps/src/can_controller.hpp
@@ -61,7 +61,7 @@ struct msg_board {
     bool c_act_pgood, l_act_pgood, r_act_pgood;
     bool wheel_enable;
     bool charge_temperature_good;
-    bool emergency_stop;
+    bool emergency_state;
 } __attribute__((aligned(4)));
 
 struct msg_control {

--- a/lexxpluss_apps/src/zcan_board.hpp
+++ b/lexxpluss_apps/src/zcan_board.hpp
@@ -81,7 +81,7 @@ public:
             if (message.wait_shutdown_state) {
                 packedData[0] |= 0b00001000;
             }
-            if (message.emergency_stop) {
+            if (message.emergency_state) {
                 packedData[0] |= 0b00000100;
             }
             if (message.safety_lidar_asserted) {


### PR DESCRIPTION
ref: [AMRSW-1112](https://lexxpluss.atlassian.net/browse/AMRSW-1112)

This PR is motivated to publish whether SCB state is in SUSPEND or RESUME_WAIT to clarify the reason of emergency stop.

In the current implementation, SCB firmware publishes whether it is in emergency stop status or not. But we found that this information is not enough to handle emergency status in ROS layer. Concretely, When SCB state is in SUSPEND or RESUME_WAIT, we want ROS systems to be emergency status but not to send requests of making SCB status emergency.

[AMRSW-1112]: https://lexxpluss.atlassian.net/browse/AMRSW-1112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ