### PR TITLE
use uart2 as default

### DIFF
--- a/extra/boards/arm/lexxpluss_scb/lexxpluss_scb.dts
+++ b/extra/boards/arm/lexxpluss_scb/lexxpluss_scb.dts
@@ -35,8 +35,8 @@
 
 	chosen {
 		zephyr,code-partition = &slot0_partition;
-		zephyr,console = &usart1;
-		zephyr,shell-uart = &usart1;
+		zephyr,console = &usart2;
+		zephyr,shell-uart = &usart2;
 		zephyr,sram = &sram0;
 		zephyr,flash = &flash0;
 		zephyr,dtcm = &dtcm;


### PR DESCRIPTION
ref: [AMRSW-1153](https://lexxpluss.atlassian.net/browse/AMRSW-1153)

This PR is motivated to use UART2 as default. Originally, UART2 was used as default. But UART2 couldn't work expectedly because of hardware issue. So we decied to use UART1 as default for workaround.

Now, this hardware issue was solved. So this PR reverts above workaround.


[AMRSW-1153]: https://lexxpluss.atlassian.net/browse/AMRSW-1153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ