### PR TITLE
AMRSW-1158-fix-artifact-location-path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
           INITIAL_FIRMWARE_PATH: LexxHard-SensorControlBoard-Firmware-Initial-${{ github.ref_name }}.bin
           UPDATE_FIRMWARE_PATH: LexxHard-SensorControlBoard-Firmware-Update-${{ github.ref_name }}.bin
         with:
-          asset_paths: '["${{ env.INITIAL_FIRMWARE_PATH }}", "${{ UPDATE_FIRMWARE_PATH }}"]'
+          asset_paths: '["${{ env.INITIAL_FIRMWARE_PATH }}", "${{ env.UPDATE_FIRMWARE_PATH }}"]'
       - name: Notification
         uses: act10ns/slack@v1
         with:


### PR DESCRIPTION
ref: [AMRSW-1158](https://lexxpluss.atlassian.net/browse/AMRSW-1158)

This PR is motivated to fix missing `env` prefix.

[AMRSW-1158]: https://lexxpluss.atlassian.net/browse/AMRSW-1158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ