### PR TITLE
Amrsw 1159 feat add new key swithc support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,18 +47,23 @@ jobs:
           cp -a /home/user/.cmake $HOME
           make IN_HOST=1 WORKDIR=$(pwd) setup
           make IN_HOST=1 WORKDIR=$(pwd) bootloader
-          make IN_HOST=1 WORKDIR=$(pwd) VERSION=${{ env.version }} firmware
-          make IN_HOST=1 WORKDIR=$(pwd) initial_image
-          mv ./firmware.bin LexxHard-SensorControlBoard-Firmware-Initial-${{ github.ref_name }}.bin
-          mv ./build/zephyr/zephyr.signed.confirmed.bin LexxHard-SensorControlBoard-Firmware-Update-${{ github.ref_name }}.bin
+          make IN_HOST=1 WORKDIR=$(pwd) VERSION=${{ env.version }} firmware_initial
+          make IN_HOST=1 WORKDIR=$(pwd) clean
+          make IN_HOST=1 WORKDIR=$(pwd) VERSION=${{ env.version }} firmware_two_state_ksw_initial
+          mv ./out/firmware.bin LexxHard-SensorControlBoard-Firmware-Initial-${{ github.ref_name }}.bin
+          mv ./out/zephyr.signed.confirmed.bin LexxHard-SensorControlBoard-Firmware-Update-${{ github.ref_name }}.bin
+          mv ./out/firmware_two_state_ksw.bin LexxHard-SensorControlBoard-Firmware-Two-State-KeySwitch-Initial-${{ github.ref_name }}.bin
+          mv ./out/zephyr_two_state_ksw.signed.confirmed.bin LexxHard-SensorControlBoard-Firmware-Two-State-KeySwitch-Update-${{ github.ref_name }}.bin
       - name: Upload release binaries
         uses: alexellis/upload-assets@0.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INITIAL_FIRMWARE_PATH: LexxHard-SensorControlBoard-Firmware-Initial-${{ github.ref_name }}.bin
           UPDATE_FIRMWARE_PATH: LexxHard-SensorControlBoard-Firmware-Update-${{ github.ref_name }}.bin
+          INITIAL_FIRMWARE_TWO_STATE_KSW_PATH: LexxHard-SensorControlBoard-Firmware-Two-State-KeySwitch-Initial-${{ github.ref_name }}.bin
+          UPDATE_FIRMWARE_TWO_STATE_SKW_PATH: LexxHard-SensorControlBoard-Firmware-Two-State-KeySwitch-Update-${{ github.ref_name }}.bin
         with:
-          asset_paths: '["${{ env.INITIAL_FIRMWARE_PATH }}", "${{ env.UPDATE_FIRMWARE_PATH }}"]'
+          asset_paths: '["${{ env.INITIAL_FIRMWARE_PATH }}", "${{ env.UPDATE_FIRMWARE_PATH }}", "${{ env.INITIAL_FIRMWARE_TWO_STATE_KSW_PATH }}", "${{ env.UPDATE_FIRMWARE_TWO_STATE_SKW_PATH }}"]'
       - name: Notification
         uses: act10ns/slack@v1
         with:

--- a/lexxpluss_apps/CMakeLists.txt
+++ b/lexxpluss_apps/CMakeLists.txt
@@ -35,6 +35,10 @@ if(ENABLE_INTERLOCK)
     add_definitions(-DENABLE_INTERLOCK)
 endif()
 
+if(USE_TWO_STATE_KEY_SWITCH)
+    add_definitions(-DUSE_TWO_STATE_KEY_SWITCH)
+endif()
+
 if(VERSION)
     add_definitions(-DVERSION=${VERSION})
 endif()

--- a/lexxpluss_apps/src/board_controller.cpp
+++ b/lexxpluss_apps/src/board_controller.cpp
@@ -263,7 +263,7 @@ private:
 class key_switch { // Variables Implemented
 public:
     enum class STATE {
-        LEFT, RIGHT, UNKNOWN
+        LEFT, RIGHT, CENTER, UNKNOWN
     };
     void poll() {
         gpio_dt_spec gpio_left_dev = GET_GPIO(key_switch_left);
@@ -293,11 +293,14 @@ public:
             count = COUNT;
             asserted = true;
         }
+
         if (asserted) {
             if(now_left == 0 && now_right == 1)
                 state = STATE::LEFT;
             else if(now_left == 1 && now_right == 0)
                 state = STATE::RIGHT;
+            else if(now_left == 1 && now_right == 1)
+                state = STATE::CENTER;
             else
                 state = STATE::UNKNOWN;
         }
@@ -306,8 +309,14 @@ public:
         state = STATE::UNKNOWN;
     }
     STATE get_state() const {return state;}
+    bool is_running() const {
+        return state == STATE::RIGHT;
+    }
+    bool is_manual_charge() const {
+        return state == STATE::CENTER;
+    }
     bool is_maintenance() const {
-        return state != STATE::RIGHT;
+        return !is_running() && !is_manual_charge();
     }
 private:
     STATE state{STATE::UNKNOWN};
@@ -1339,12 +1348,12 @@ private:
 
         switch (state) {
         case POWER_STATE::OFF:
-            if (ksw.is_maintenance() || is_lockdown) {
+            if (should_turn_off() || is_lockdown) {
                 // empty here
-            } else if(psw.get_state() == power_switch::STATE::RELEASED){
-                set_new_state(POWER_STATE::WAIT_SW);
-            } else if (mc.is_plugged()) {
+            } else if (should_manual_charge()) {
                 set_new_state(POWER_STATE::POST);
+            } else if (psw.get_state() == power_switch::STATE::RELEASED){
+                set_new_state(POWER_STATE::WAIT_SW);
             }
             break;
         case POWER_STATE::TIMEROFF:
@@ -1352,20 +1361,15 @@ private:
                 set_new_state(POWER_STATE::OFF);
             break;
         case POWER_STATE::WAIT_SW:
-            if (ksw.is_maintenance()) {
+            if (should_turn_off() || should_manual_charge()) {
                 set_new_state(POWER_STATE::OFF);
             } else if (psw.get_state() != power_switch::STATE::RELEASED) {
                 poweron_by_switch = true;
                 set_new_state(POWER_STATE::POST);
-            } else if (mc.is_plugged()) {
-                set_new_state(POWER_STATE::POST);
             }
             break;
         case POWER_STATE::POST:
-            if (ksw.is_maintenance()) {
-                set_new_state(POWER_STATE::OFF);
-            } else if (!poweron_by_switch && !mc.is_plugged()) {
-                LOG_DBG("unplugged from manual charger\n");
+            if (should_turn_off()) {
                 set_new_state(POWER_STATE::OFF);
             } else if (bmu.is_ok() && psw.get_state() == power_switch::STATE::RELEASED) {
                 LOG_DBG("BMU and temperature OK\n");
@@ -1382,23 +1386,23 @@ private:
                 set_new_state(POWER_STATE::OFF);
             } else if (should_lockdown()) {
                 set_new_state(POWER_STATE::LOCKDOWN);
-            } else if (ksw.is_maintenance() || psw_state != power_switch::STATE::RELEASED || mbd.power_off_from_ros() || !bmu.is_ok()) {
+            } else if (should_turn_off() || psw_state != power_switch::STATE::RELEASED || mbd.power_off_from_ros() || !bmu.is_ok()) {
                 set_new_state(POWER_STATE::OFF_WAIT);
+            } else if (should_manual_charge()) {
+                LOG_DBG("plugged to manual charger\n");
+                set_new_state(POWER_STATE::MANUAL_CHARGE);
             } else if (esw.is_asserted()) {
                 LOG_DBG("emergency switch asserted\n");
                 set_new_state(POWER_STATE::SUSPEND);
             } else if (!esw.is_asserted() && !mbd.emergency_stop_from_ros() && mbd.is_ready() && !sl.is_asserted()) {
                 LOG_DBG("not emergency and heartbeat OK\n");
                 set_new_state(POWER_STATE::NORMAL);
-            } else if (mc.is_plugged()) {
-                LOG_DBG("plugged to manual charger\n");
-                set_new_state(POWER_STATE::MANUAL_CHARGE);
             }
             break;
         }
         case POWER_STATE::NORMAL:
             wheel_relay_control();
-            if (ksw.is_maintenance()) {
+            if (should_lockdown() || should_turn_off() || should_manual_charge()) {
                set_new_state(POWER_STATE::OFF_WAIT);
             } else if (psw.get_state() != power_switch::STATE::RELEASED) {
                 LOG_DBG("detect power switch\n");
@@ -1424,9 +1428,6 @@ private:
             } else if (mbd.is_dead()) {
                 LOG_DBG("mainboard is dead\n");
                 set_new_state(POWER_STATE::SUSPEND);
-            } else if (mc.is_plugged()) {
-                LOG_DBG("plugged to manual charger\n");
-                set_new_state(POWER_STATE::MANUAL_CHARGE);
             } else if (!charge_guard_asserted && ac.is_docked() && bmu.is_chargable()) {
                 if(ac.is_charger_ready() == true){
                     LOG_DBG("docked to auto charger\n");
@@ -1441,7 +1442,7 @@ private:
                 set_new_state(POWER_STATE::OFF);
             } else if (should_lockdown()) {
                 set_new_state(POWER_STATE::LOCKDOWN);
-            } else if (ksw.is_maintenance() || psw_state != power_switch::STATE::RELEASED || mbd.power_off_from_ros() || !bmu.is_ok()) {
+            } else if (should_turn_off() || should_manual_charge() || psw_state != power_switch::STATE::RELEASED || mbd.power_off_from_ros() || !bmu.is_ok()) {
                 set_new_state(POWER_STATE::OFF_WAIT);
             } else if (!esw.is_asserted() && !mbd.emergency_stop_from_ros() && !sl.is_asserted()) {
                 LOG_DBG("not emergency\n");
@@ -1451,7 +1452,7 @@ private:
         }
         case POWER_STATE::RESUME_WAIT:
             wheel_relay_control();
-            if (ksw.is_maintenance()) {
+            if (should_turn_off() || should_manual_charge()) {
                set_new_state(POWER_STATE::OFF_WAIT);
             } else if (psw.get_state() != power_switch::STATE::RELEASED) {
                 LOG_DBG("detect power switch\n");
@@ -1491,7 +1492,7 @@ private:
             break;
         case POWER_STATE::AUTO_CHARGE:
             ac.update_rsoc(bmu.get_rsoc());
-            if (ksw.is_maintenance()) {
+            if (should_turn_off() || should_manual_charge()) {
                set_new_state(POWER_STATE::OFF_WAIT);
             } else if (psw.get_state() != power_switch::STATE::RELEASED) {
                 LOG_DBG("detect power switch\n");
@@ -1532,11 +1533,9 @@ private:
             }
             break;
         case POWER_STATE::MANUAL_CHARGE:
-            if (ksw.is_maintenance()) {
+            if (!should_manual_charge()) {
+               LOG_DBG("unplugged from manual charger\n");
                set_new_state(POWER_STATE::OFF_WAIT);
-            } else if (!mc.is_plugged()) {
-                LOG_DBG("unplugged from manual charger\n");
-                set_new_state(POWER_STATE::NORMAL);
             }
             break;
         case POWER_STATE::LOCKDOWN:
@@ -1735,7 +1734,7 @@ private:
         case POWER_STATE::OFF_WAIT: {
             LOG_INF("enter OFF_WAIT\n");
             timer_shutdown = k_uptime_get();    // timer reset
-            if (psw.get_state() == power_switch::STATE::PUSHED || ksw.is_maintenance())
+            if (psw.get_state() == power_switch::STATE::PUSHED || should_turn_off() || should_manual_charge())
                 shutdown_reason = SHUTDOWN_REASON::SWITCH;
             if (mbd.power_off_from_ros())
                 shutdown_reason = SHUTDOWN_REASON::ROS;
@@ -1807,6 +1806,12 @@ private:
     }
     bool is_emergency_state() const {
         return state == POWER_STATE::SUSPEND || state == POWER_STATE::RESUME_WAIT;
+    }
+    bool should_turn_off() {
+        return  ksw.is_maintenance() || (ksw.is_manual_charge() && !mc.is_plugged()) || (!ksw.is_manual_charge() && mc.is_plugged());
+    }
+    bool should_manual_charge() {
+        return ksw.is_manual_charge() && mc.is_plugged();
     }
     
     power_switch psw;

--- a/lexxpluss_apps/src/board_controller.cpp
+++ b/lexxpluss_apps/src/board_controller.cpp
@@ -313,10 +313,18 @@ public:
         return state == STATE::RIGHT;
     }
     bool is_manual_charge() const {
+#ifndef USE_TWO_STATE_KEY_SWITCH
         return state == STATE::CENTER;
+#else
+        return !is_running();
+#endif
     }
     bool is_maintenance() const {
+#ifndef USE_TWO_STATE_KEY_SWITCH
         return !is_running() && !is_manual_charge();
+#else
+        return false;
+#endif
     }
 private:
     STATE state{STATE::UNKNOWN};


### PR DESCRIPTION
ref: [AMRSW-1159](https://lexxpluss.atlassian.net/browse/AMRSW-1159)

This PR is motivated to add new tri-state (left/center/right) key switch support. Though, there are some robots which contains old two-state key switch. So this PR adds a new workflow for building firmware which are for these robots.

This PR contains following modifications.

* Update key_switch class to handle tri-state (left / center / right). And these states means as following.
  * right (running) : In running state,  LexxAuto can be launch and it can run arbitrary tasks. But I cannot be in manual charging. This means that it turns down when manual charging cable is plugged.
  * center (manual charging) :  In manual charging state,  LexxAuto can be launch but it cannot run arbitrary tasks. It can only be in manual charging. This means that it turns down when manual chargin cable is unplugged.
  * left (maintenance) : In maintenance state, robot cannot do anything by itself. But we can use its console vie tty.
* Add a target to make a firmware for robots which contains two-state key switch.
* Update workflow to create firmware for using two-state key switch 

This PR is tested in robot. And It seemed that it works correctly.

[AMRSW-1159]: https://lexxpluss.atlassian.net/browse/AMRSW-1159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ