### PR TITLE
AMRSW-1283 enable lockdown manually

### DIFF
--- a/lexxpluss_apps/src/board_controller.hpp
+++ b/lexxpluss_apps/src/board_controller.hpp
@@ -41,6 +41,7 @@ struct msg_rcv_pb {
     bool ros_power_off;
     bool ros_heartbeat_timeout;
     bool ros_wheel_power_off;
+    bool ros_lockdown;
 } __attribute__((aligned(4)));
 
 

--- a/lexxpluss_apps/src/can_controller.cpp
+++ b/lexxpluss_apps/src/can_controller.cpp
@@ -113,7 +113,6 @@ public:
     }
     void brd_emgoff() {
         ros2board.emergency_stop = false;
-        ros2board.lockdown = false;
         heartbeat_timeout = false;
 
         // if changed send to board_controller

--- a/lexxpluss_apps/src/can_controller.cpp
+++ b/lexxpluss_apps/src/can_controller.cpp
@@ -91,6 +91,7 @@ public:
                 ros2board.heart_beat = false;
                 ros2board.power_off = false;
                 ros2board.wheel_power_off = false;
+                ros2board.lockdown = false;
                 heartbeat_timeout = false;
             }
 
@@ -112,6 +113,7 @@ public:
     }
     void brd_emgoff() {
         ros2board.emergency_stop = false;
+        ros2board.lockdown = false;
         heartbeat_timeout = false;
 
         // if changed send to board_controller
@@ -147,9 +149,10 @@ private:
         msg_board_to_pb.ros_power_off = ros2board.power_off;
         msg_board_to_pb.ros_heartbeat_timeout = heartbeat_timeout;
         msg_board_to_pb.ros_wheel_power_off = ros2board.wheel_power_off;
+        msg_board_to_pb.ros_lockdown = ros2board.lockdown;
     }
     msg_board board2ros{0};
-    msg_control ros2board{true, false, false, false};
+    msg_control ros2board{true, false, false, false, false};
     board_controller::msg_rcv_pb msg_board_to_pb{0};
     uint32_t prev_cycle_ros{0}, prev_cycle_send{0};
     bool heartbeat_timeout{false};

--- a/lexxpluss_apps/src/can_controller.hpp
+++ b/lexxpluss_apps/src/can_controller.hpp
@@ -65,7 +65,7 @@ struct msg_board {
 } __attribute__((aligned(4)));
 
 struct msg_control {
-    bool emergency_stop, power_off, wheel_power_off, heart_beat;
+    bool emergency_stop, power_off, wheel_power_off, heart_beat, lockdown;
 } __attribute__((aligned(4)));
 
 void init();

--- a/lexxpluss_apps/src/zcan_board.hpp
+++ b/lexxpluss_apps/src/zcan_board.hpp
@@ -116,7 +116,7 @@ public:
             msg.power_off = frame.data[1] & 0x01;
             msg.wheel_power_off = frame.data[2] & 0x01;
             msg.heart_beat = frame.data[3] & 0x01;
-            msg.lockdown = frame.data[4] & 0x01;
+            msg.lockdown = (4 < frame.dlc) ? frame.data[4] & 0x01 : 0;
 
             if(prev_msg.emergency_stop != msg.emergency_stop) {
                 LOG_INF("Emergency Stop: %d", msg.emergency_stop);

--- a/lexxpluss_apps/src/zcan_board.hpp
+++ b/lexxpluss_apps/src/zcan_board.hpp
@@ -116,6 +116,7 @@ public:
             msg.power_off = frame.data[1] & 0x01;
             msg.wheel_power_off = frame.data[2] & 0x01;
             msg.heart_beat = frame.data[3] & 0x01;
+            msg.lockdown = frame.data[4] & 0x01;
 
             if(prev_msg.emergency_stop != msg.emergency_stop) {
                 LOG_INF("Emergency Stop: %d", msg.emergency_stop);
@@ -132,6 +133,10 @@ public:
             if (prev_msg.heart_beat != msg.heart_beat) {
                 LOG_INF("Heart Beat: %d", msg.heart_beat);
                 prev_msg.heart_beat = msg.heart_beat;
+            }
+            if (prev_msg.lockdown != msg.lockdown) {
+                LOG_INF("Lockdown: %d", msg.lockdown);
+                prev_msg.lockdown = msg.lockdown;
             }
 
             while (k_msgq_put(&can_controller::msgq_control, &msg, K_NO_WAIT) != 0)

--- a/lexxpluss_apps/src/zcan_board.hpp
+++ b/lexxpluss_apps/src/zcan_board.hpp
@@ -116,7 +116,7 @@ public:
             msg.power_off = frame.data[1] & 0x01;
             msg.wheel_power_off = frame.data[2] & 0x01;
             msg.heart_beat = frame.data[3] & 0x01;
-            msg.lockdown = (4 < frame.dlc) ? frame.data[4] & 0x01 : 0;
+            msg.lockdown = (4 < frame.dlc) ? frame.data[4] & 0x01 : 0;  // this condition is for backward compatibility
 
             if(prev_msg.emergency_stop != msg.emergency_stop) {
                 LOG_INF("Emergency Stop: %d", msg.emergency_stop);


### PR DESCRIPTION
ref: [AMRSW-1283](https://lexxpluss.atlassian.net/browse/AMRSW-1283)

This PR is motivated to add a feature about making robot lockdown manually. This is achieved by adding following modifications.

* Handling lockdown requests from ROS
* Reset flags about heartbeat detection when robot turns into STANDBY state. ROS system is launched after `STANDBY` state. So This codes are motivated to clear unexpected heartbeat detection.
* Drop all items in `msgq_board_pb_rx` queue when robot turn s into `OFF` state.

Applying this PR and using correct version software, I found that robot turned into lockdown when I plugged out can cable.


[AMRSW-1283]: https://lexxpluss.atlassian.net/browse/AMRSW-1283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ