### PR TITLE
Amrsw 1447 add three inductive senssor support

### DIFF
--- a/lexxpluss_apps/src/board_controller.cpp
+++ b/lexxpluss_apps/src/board_controller.cpp
@@ -1275,6 +1275,16 @@ public:
             return;
         }
 
+        // eo_option_1 is used as power source for third inductive sensor
+        {
+            gpio_dt_spec gpio_dev = GET_GPIO(eo_option_1);
+            if (!gpio_is_ready_dt(&gpio_dev)) {
+                LOG_ERR("gpio_is_ready_dt Failed\n");
+                return;
+            }
+            gpio_pin_set_dt(&gpio_dev, true);
+        }
+
         esw.set_callback([&](){
             this->bsw.request_reset();
         });

--- a/lexxpluss_apps/src/board_controller.cpp
+++ b/lexxpluss_apps/src/board_controller.cpp
@@ -1279,7 +1279,7 @@ public:
         {
             gpio_dt_spec gpio_dev = GET_GPIO(eo_option_1);
             if (!gpio_is_ready_dt(&gpio_dev)) {
-                LOG_ERR("gpio_is_ready_dt Failed\n");
+                LOG_ERR("gpio_is_ready_dt for eo_option_1 Failed\n");
                 return;
             }
             gpio_pin_set_dt(&gpio_dev, true);

--- a/lexxpluss_apps/src/gpio_controller.cpp
+++ b/lexxpluss_apps/src/gpio_controller.cpp
@@ -44,7 +44,7 @@ char __aligned(4) msgq_control_buffer[8 * sizeof (msg_control)];
 
 class gpio_controller_impl {
 public:
-    static constexpr int32_t POLL_INTERVAL_MS = 100;
+    static constexpr int32_t POLL_INTERVAL_MS = 20;
 
     int init() {
         k_msgq_init(&msgq, msgq_buffer, sizeof (msg), 8);

--- a/lexxpluss_apps/src/main.cpp
+++ b/lexxpluss_apps/src/main.cpp
@@ -125,6 +125,12 @@ void init_gpio() {
     gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(d_enc_ena), gpios);
     if (gpio_is_ready_dt(&gpio_dev))
         gpio_pin_configure_dt(&gpio_dev, GPIO_OUTPUT_LOW | GPIO_ACTIVE_HIGH);
+    gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(eo_option_1), gpios);
+    if (gpio_is_ready_dt(&gpio_dev))
+        gpio_pin_configure_dt(&gpio_dev, GPIO_OUTPUT_LOW | GPIO_ACTIVE_HIGH);
+    gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(eo_option_2), gpios);
+    if (gpio_is_ready_dt(&gpio_dev))
+        gpio_pin_configure_dt(&gpio_dev, GPIO_OUTPUT_LOW | GPIO_ACTIVE_HIGH);
     
     // Input
     gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(ps_sw_in), gpios);


### PR DESCRIPTION
ref: [AMRSW-1447](https://lexxpluss.atlassian.net/browse/AMRSW-1447)

https://www.notion.so/lexxpluss/Additional-Inductive-Sensor-for-Rollbox-Detection-1c8a91d8f615807f9cd3fe03b34b18d5?pvs=4#1cca91d8f61580e1aed3ea145cb6cb50

This PR is motivated to add extra (3rd) inductive sensor support and increase the polling rate of gpio for increasing the accuracy of gripping. This is achieved by follwoings.

* Assign H to eo_option_1 to provide power for extra inductive sensor
* Change POLL_INTERVAL_MS in gpio_controller from 100 to 20

These modifications are checked in real robot with screen console.

[AMRSW-1447]: https://lexxpluss.atlassian.net/browse/AMRSW-1447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ