### PR TITLE
AMRSW-1340 add logging for power off reasons

### DIFF
--- a/lexxpluss_apps/src/board_controller.cpp
+++ b/lexxpluss_apps/src/board_controller.cpp
@@ -1775,6 +1775,15 @@ private:
             if (!bmu.is_ok())
                 shutdown_reason = SHUTDOWN_REASON::BMU;
 
+            // dump reasons about power off for debugging
+            LOG_INF("Dump power off reasons\n"
+                    "  state: %d, psw.get_state(): %d, shouwl_turn_off(): %d, should_manual_charge():%d\n"
+                    "  is_working_mode_changed(): %d, mbd.power_off_from_ros(): %d, bmu.is_ok(): %d\n"
+                    "  ksw.is_off():%d, ksw.is_maintenance(): %d, mc.is_plugged(): %d",
+                    static_cast<int>(state), static_cast<int>(psw.get_state()), should_turn_off(), should_manual_charge(),
+                    is_working_mode_changed(), mbd.power_off_from_ros(), bmu.is_ok(),
+                    ksw.is_off(), ksw.is_maintenance(), mc.is_plugged());
+
             // Set LED
             led_controller::msg const msg_led{led_controller::msg::SHOWTIME, 60000};
             while (k_msgq_put(&led_controller::msgq, &msg_led, K_NO_WAIT) != 0)

--- a/lexxpluss_apps/src/board_controller.cpp
+++ b/lexxpluss_apps/src/board_controller.cpp
@@ -1361,6 +1361,9 @@ private:
                 LOG_DBG("wheel power control %d!\n", wheel_poweroff);
             }
         };
+        auto wheel_switch_control = [&](){
+            wsw.set_disable(ksw.is_maintenance());
+        };
         
         psw.poll();
         rsw.poll();
@@ -1430,7 +1433,7 @@ private:
             wheel_relay_control();
             wheel_switch_control();
             if (should_turn_off() || is_working_mode_changed()) {
-r              set_new_state(POWER_STATE::OFF_WAIT);
+               set_new_state(POWER_STATE::OFF_WAIT);
             } else if (should_lockdown()) {
                set_new_state(POWER_STATE::LOCKDOWN);
             } else if (psw.get_state() != power_switch::STATE::RELEASED) {
@@ -1523,6 +1526,7 @@ r              set_new_state(POWER_STATE::OFF_WAIT);
             }
             break;
         case POWER_STATE::AUTO_CHARGE:
+            wheel_switch_control();
             ac.update_rsoc(bmu.get_rsoc());
             if (should_turn_off() || is_working_mode_changed()) {
                set_new_state(POWER_STATE::OFF_WAIT);
@@ -1604,7 +1608,6 @@ r              set_new_state(POWER_STATE::OFF_WAIT);
         case POWER_STATE::NORMAL: {
             LOG_INF("leave NORMAL");
             k_timer_stop(&charge_guard_timeout);
-            wsw.set_disable(true);
         } break;
         case POWER_STATE::POST: {
             LOG_INF("leave POST\n");
@@ -1623,7 +1626,6 @@ r              set_new_state(POWER_STATE::OFF_WAIT);
             LOG_INF("leave AUTO_CHARGE");
             k_timer_stop(&current_check_timeout);
             ac.force_stop();
-            wsw.set_disable(true);
         } break;
         case POWER_STATE::MANUAL_CHARGE: {
             LOG_INF("leave MANUAL_CHARGE\n");


### PR DESCRIPTION
ref: [AMRSW-1491](https://lexxpluss.atlassian.net/browse/AMRSW-1491)

This PR is motivated to add logging message about shutdown reasons such as followings. This logs is expected to be used for investigation of unexpected shutdown.

```
Apr 21 15:16:18 V711004 mainboard[1374]: [00:09:59.722,000] <inf> board: Dump power off reasons
Apr 21 15:16:18 V711004 mainboard[1374]:   state: 9, psw.get_state(): 1, shouwl_turn_off(): 0, should_manual_charge():0
Apr 21 15:16:18 V711004 mainboard[1374]:   is_working_mode_changed(): 0, mbd.power_off_from_ros(): 0, bmu.is_ok(): 1
Apr 21 15:16:18 V711004 mainboard[1374]:   ksw.is_off():0, ksw.is_maintenance(): 0, mc.is_plugged(): 0
```

[AMRSW-1491]: https://lexxpluss.atlassian.net/browse/AMRSW-1491?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ