### PR TITLE
feat/AMRSW-1764 use time multiplexing for uss sampling

### DIFF
--- a/lexxpluss_apps/src/uss_controller.cpp
+++ b/lexxpluss_apps/src/uss_controller.cpp
@@ -95,7 +95,7 @@ public:
             k_mutex_unlock(&this->lock);
         } else {
             LOG_WRN("Failed to acquire mutex in get_distance");
-           return;
+            return;
         }
     }
     void update_once() {

--- a/lexxpluss_apps/src/uss_controller.cpp
+++ b/lexxpluss_apps/src/uss_controller.cpp
@@ -136,12 +136,14 @@ private:
     mutable struct k_mutex lock;
 } fetcher[4];
 
+static uint32_t fetch_delay_ms = 1; // Default delay of 1ms
+
 void fetch_thread(void *, void *, void *)
 {
     while (true) {
         for (auto &f : fetcher) {
             f.update_once();
-            k_msleep(1);
+            k_msleep(fetch_delay_ms);
         }
     }
 }


### PR DESCRIPTION
ref: [AMRSW-1763](https://lexxpluss.atlassian.net/browse/AMRSW-1763)

This PR is motivated to use time multiplexing for uss sampling. This is achieved by following modifications.

* Combine all fetching task into one task to fetch uss samples sequentially
* Use mutex when accessing uss output value

I checked this modification in following environment.

**expected distance**
* uss0: about 0.72
* uss1: about 1.43
* uss2: about 0.43
* uss3: 100 (infinity)
* uss4: 100 (infinity)


I captured 4096 samples from each sensors and calculate avg, std, max and min values in current implementation and this PR implementation. These results are following.

**PR implementation**
* uss0: avg=0.717978, std=0.001389, min=0.715000, max=0.725000
* uss1: avg=1.412455, std=0.001977, min=1.403000, max=1.420000
* uss2: avg=0.432606, std=0.001656, min=0.426000, max=0.440000
* uss3: avg=100.000000, std=0.000000, min=100.000000, max=100.000000
* uss4: avg=100.000000, std=0.000000, min=100.000000, max=100.000000

**current implementation**
* uss0: avg=0.713663, std=0.016607, min=0.598400, max=0.722400
* uss1: avg=1.412311, std=0.001851, min=1.404000, max=1.417600
* uss2: avg=0.431950, std=0.001421, min=0.427200, max=0.436400
* uss3: avg=100.000000, std=0.000000, min=100.000000, max=100.000000
* uss4: avg=100.000000, std=0.000000, min=100.000000, max=100.000000

From above results, we can see that the outliers of uss0 decreased in PR implementation.


[AMRSW-1763]: https://lexxpluss.atlassian.net/browse/AMRSW-1763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ