### PR TITLE
fix/AMRSW-2862 iim42652 FS_SEL bit-shift and sensitivity sync

### DIFF
--- a/extra/drivers/sensor/iim42652/iim42652.c
+++ b/extra/drivers/sensor/iim42652/iim42652.c
@@ -46,21 +46,19 @@ static const uint16_t iim42652_gyro_sensitivity_x10[IIM42652_GYRO_FS_COUNT] = {
 	[GYRO_FS_15DPS]   = IIM42652_GYRO_SENS_15DPS_X10,
 };
 
+/* Callers (iim42652_set_fs, iim42652_attr_set, devicetree-backed init) are
+ * responsible for range-checking sf_idx before reaching here, so the cached
+ * SI conversion factor always stays in sync with what gets written to the
+ * FS register. The assert catches programming mistakes during development. */
 static void update_accel_sensitivity(struct iim42652_data *data, uint8_t sf_idx)
 {
-	if (sf_idx >= IIM42652_ACCEL_FS_COUNT) {
-		LOG_ERR("Invalid accel FS_SEL %u", sf_idx);
-		return;
-	}
+	__ASSERT_NO_MSG(sf_idx < IIM42652_ACCEL_FS_COUNT);
 	data->accel_sensitivity_shift = iim42652_accel_sensitivity_shift[sf_idx];
 }
 
 static void update_gyro_sensitivity(struct iim42652_data *data, uint8_t sf_idx)
 {
-	if (sf_idx >= IIM42652_GYRO_FS_COUNT) {
-		LOG_ERR("Invalid gyro FS_SEL %u", sf_idx);
-		return;
-	}
+	__ASSERT_NO_MSG(sf_idx < IIM42652_GYRO_FS_COUNT);
 	data->gyro_sensitivity_x10 = iim42652_gyro_sensitivity_x10[sf_idx];
 }
 

--- a/extra/drivers/sensor/iim42652/iim42652.c
+++ b/extra/drivers/sensor/iim42652/iim42652.c
@@ -24,9 +24,34 @@
 
 LOG_MODULE_REGISTER(IIM42652, CONFIG_SENSOR_LOG_LEVEL);
 
-static const uint16_t iim42652_gyro_sensitivity_x10[] = {
-	1310, 655, 328, 164
+/* Gyro sensitivity (LSB per deg/s, x10) indexed by GYRO_FS_SEL register code:
+ *   FS_SEL=0 -> +/-2000 DPS,   16.4 LSB/(deg/s)
+ *   FS_SEL=1 -> +/-1000 DPS,   32.8
+ *   FS_SEL=2 -> +/-500  DPS,   65.5
+ *   FS_SEL=3 -> +/-250  DPS,  131.0
+ *   FS_SEL=4 -> +/-125  DPS,  262.0
+ *   FS_SEL=5 -> +/-62.5 DPS,  524.3
+ *   FS_SEL=6 -> +/-31.25 DPS, 1048.6
+ *   FS_SEL=7 -> +/-15.625 DPS,2097.2
+ */
+static const uint16_t iim42652_gyro_sensitivity_x10[8] = {
+	164, 328, 655, 1310, 2620, 5243, 10486, 20972
 };
+
+/* Update cached SI conversion factors to match a target FS_SEL.
+ * Accel sensitivity_shift formula: 2 ^ shift = LSB / g.
+ *   FS_SEL=0 (+/-16G):  2048 LSB/g -> shift = 11
+ *   FS_SEL=3 (+/-2G):  16384 LSB/g -> shift = 14
+ */
+static void update_accel_sensitivity(struct iim42652_data *data, uint8_t sf_idx)
+{
+	data->accel_sensitivity_shift = 11 + sf_idx;
+}
+
+static void update_gyro_sensitivity(struct iim42652_data *data, uint8_t sf_idx)
+{
+	data->gyro_sensitivity_x10 = iim42652_gyro_sensitivity_x10[sf_idx];
+}
 
 /* see "Accelerometer Measurements" section from register map description */
 static void iim42652_convert_accel(struct sensor_value *val,
@@ -264,6 +289,16 @@ static int iim42652_attr_set(const struct device *dev,
 
 	__ASSERT_NO_MSG(val != NULL);
 
+	/* ODR and FS are written to the chip only during turn_on_sensor().
+	 * Reject runtime changes; caller must turn_off_sensor() first so
+	 * the cached config matches what was last written to hardware. */
+	if ((attr == SENSOR_ATTR_SAMPLING_FREQUENCY ||
+	     attr == SENSOR_ATTR_FULL_SCALE) &&
+	    drv_data->sensor_started) {
+		LOG_WRN("Config change requires turn_off_sensor first");
+		return -EBUSY;
+	}
+
 	switch (chan) {
 	case SENSOR_CHAN_ACCEL_X:
 	case SENSOR_CHAN_ACCEL_Y:
@@ -283,6 +318,8 @@ static int iim42652_attr_set(const struct device *dev,
 				return -EINVAL;
 			} else {
 				drv_data->accel_sf = val->val1;
+				update_accel_sensitivity(drv_data,
+							 drv_data->accel_sf);
 			}
 		} else {
 			LOG_ERR("Not supported ATTR");
@@ -308,6 +345,8 @@ static int iim42652_attr_set(const struct device *dev,
 				return -EINVAL;
 			} else {
 				drv_data->gyro_sf = val->val1;
+				update_gyro_sensitivity(drv_data,
+							drv_data->gyro_sf);
 			}
 		} else {
 			LOG_ERR("Not supported ATTR");
@@ -405,8 +444,8 @@ static int iim42652_init(const struct device *dev)
 	iim42652_data_init(drv_data, cfg);
 	iim42652_sensor_init(dev);
 
-	drv_data->accel_sensitivity_shift = 14 - 3;
-	drv_data->gyro_sensitivity_x10 = iim42652_gyro_sensitivity_x10[3];
+	update_accel_sensitivity(drv_data, drv_data->accel_sf);
+	update_gyro_sensitivity(drv_data, drv_data->gyro_sf);
 
 #ifdef CONFIG_IIM42652_TRIGGER
 	if (iim42652_init_interrupt(dev) < 0) {

--- a/extra/drivers/sensor/iim42652/iim42652.c
+++ b/extra/drivers/sensor/iim42652/iim42652.c
@@ -24,32 +24,43 @@
 
 LOG_MODULE_REGISTER(IIM42652, CONFIG_SENSOR_LOG_LEVEL);
 
-/* Gyro sensitivity (LSB per deg/s, x10) indexed by GYRO_FS_SEL register code:
- *   FS_SEL=0 -> +/-2000 DPS,   16.4 LSB/(deg/s)
- *   FS_SEL=1 -> +/-1000 DPS,   32.8
- *   FS_SEL=2 -> +/-500  DPS,   65.5
- *   FS_SEL=3 -> +/-250  DPS,  131.0
- *   FS_SEL=4 -> +/-125  DPS,  262.0
- *   FS_SEL=5 -> +/-62.5 DPS,  524.3
- *   FS_SEL=6 -> +/-31.25 DPS, 1048.6
- *   FS_SEL=7 -> +/-15.625 DPS,2097.2
- */
-static const uint16_t iim42652_gyro_sensitivity_x10[8] = {
-	164, 328, 655, 1310, 2620, 5243, 10486, 20972
+/* Sensitivity tables indexed by FS_SEL register code.
+ * Values come from the IIM-42652 datasheet via the macros in iim42652_reg.h.
+ * Designated initializers ensure the entry order matches the FS_SEL enum
+ * regardless of source order, so adding entries elsewhere stays safe. */
+static const uint8_t iim42652_accel_sensitivity_shift[IIM42652_ACCEL_FS_COUNT] = {
+	[ACCEL_FS_16G] = IIM42652_ACCEL_SENS_16G_SHIFT,
+	[ACCEL_FS_8G]  = IIM42652_ACCEL_SENS_8G_SHIFT,
+	[ACCEL_FS_4G]  = IIM42652_ACCEL_SENS_4G_SHIFT,
+	[ACCEL_FS_2G]  = IIM42652_ACCEL_SENS_2G_SHIFT,
 };
 
-/* Update cached SI conversion factors to match a target FS_SEL.
- * Accel sensitivity_shift formula: 2 ^ shift = LSB / g.
- *   FS_SEL=0 (+/-16G):  2048 LSB/g -> shift = 11
- *   FS_SEL=3 (+/-2G):  16384 LSB/g -> shift = 14
- */
+static const uint16_t iim42652_gyro_sensitivity_x10[IIM42652_GYRO_FS_COUNT] = {
+	[GYRO_FS_2000DPS] = IIM42652_GYRO_SENS_2000DPS_X10,
+	[GYRO_FS_1000DPS] = IIM42652_GYRO_SENS_1000DPS_X10,
+	[GYRO_FS_500DPS]  = IIM42652_GYRO_SENS_500DPS_X10,
+	[GYRO_FS_250DPS]  = IIM42652_GYRO_SENS_250DPS_X10,
+	[GYRO_FS_125DPS]  = IIM42652_GYRO_SENS_125DPS_X10,
+	[GYRO_FS_62DPS]   = IIM42652_GYRO_SENS_62DPS_X10,
+	[GYRO_FS_32DPS]   = IIM42652_GYRO_SENS_32DPS_X10,
+	[GYRO_FS_15DPS]   = IIM42652_GYRO_SENS_15DPS_X10,
+};
+
 static void update_accel_sensitivity(struct iim42652_data *data, uint8_t sf_idx)
 {
-	data->accel_sensitivity_shift = 11 + sf_idx;
+	if (sf_idx >= IIM42652_ACCEL_FS_COUNT) {
+		LOG_ERR("Invalid accel FS_SEL %u", sf_idx);
+		return;
+	}
+	data->accel_sensitivity_shift = iim42652_accel_sensitivity_shift[sf_idx];
 }
 
 static void update_gyro_sensitivity(struct iim42652_data *data, uint8_t sf_idx)
 {
+	if (sf_idx >= IIM42652_GYRO_FS_COUNT) {
+		LOG_ERR("Invalid gyro FS_SEL %u", sf_idx);
+		return;
+	}
 	data->gyro_sensitivity_x10 = iim42652_gyro_sensitivity_x10[sf_idx];
 }
 

--- a/extra/drivers/sensor/iim42652/iim42652_reg.h
+++ b/extra/drivers/sensor/iim42652/iim42652_reg.h
@@ -547,4 +547,27 @@ enum {
 	ACCEL_FS_2G,
 };
 
+/* Number of valid FS_SEL codes (matches the enums above). */
+#define IIM42652_ACCEL_FS_COUNT		4
+#define IIM42652_GYRO_FS_COUNT		8
+
+/* Datasheet sensitivities per IIM-42652 register map (Sections 3.1, 3.2).
+ * Accel sensitivity (LSB/g) is a power of 2, expressed as a right-shift
+ * applied to (raw * SENSOR_G) in iim42652_convert_accel(). */
+#define IIM42652_ACCEL_SENS_16G_SHIFT	11	/* 2048 LSB/g = 2^11 */
+#define IIM42652_ACCEL_SENS_8G_SHIFT	12	/* 4096 LSB/g = 2^12 */
+#define IIM42652_ACCEL_SENS_4G_SHIFT	13	/* 8192 LSB/g = 2^13 */
+#define IIM42652_ACCEL_SENS_2G_SHIFT	14	/* 16384 LSB/g = 2^14 */
+
+/* Gyro sensitivity stored x10 to preserve fractional LSB/(deg/s) values
+ * in integer arithmetic (see iim42652_convert_gyro()). */
+#define IIM42652_GYRO_SENS_2000DPS_X10	164	/* 16.4 LSB/(deg/s) */
+#define IIM42652_GYRO_SENS_1000DPS_X10	328	/* 32.8 LSB/(deg/s) */
+#define IIM42652_GYRO_SENS_500DPS_X10	655	/* 65.5 LSB/(deg/s) */
+#define IIM42652_GYRO_SENS_250DPS_X10	1310	/* 131.0 LSB/(deg/s) */
+#define IIM42652_GYRO_SENS_125DPS_X10	2620	/* 262.0 LSB/(deg/s) */
+#define IIM42652_GYRO_SENS_62DPS_X10	5243	/* 524.3 LSB/(deg/s) */
+#define IIM42652_GYRO_SENS_32DPS_X10	10486	/* 1048.6 LSB/(deg/s) */
+#define IIM42652_GYRO_SENS_15DPS_X10	20972	/* 2097.2 LSB/(deg/s) */
+
 #endif /* __SENSOR_IIM42652_IIM42652_REG__ */

--- a/extra/drivers/sensor/iim42652/iim42652_setup.c
+++ b/extra/drivers/sensor/iim42652/iim42652_setup.c
@@ -26,13 +26,15 @@ int iim42652_set_fs(const struct device *dev, uint16_t a_sf, uint16_t g_sf)
 	uint8_t databuf;
 	int result;
 
-	/* Validate FS_SEL indices: accel uses bit[7:5] over 4 codes (0..3),
-	 * gyro uses bit[7:5] over 8 codes (0..7). */
-	if (a_sf > 3 || g_sf > 7) {
+	/* Validate FS_SEL indices against the datasheet code counts
+	 * (4 codes for accel, 8 for gyro; see iim42652_reg.h). */
+	if (a_sf >= IIM42652_ACCEL_FS_COUNT ||
+	    g_sf >= IIM42652_GYRO_FS_COUNT) {
 		LOG_ERR("Invalid FS_SEL a=%u g=%u", a_sf, g_sf);
 		return -EINVAL;
 	}
-	__ASSERT_NO_MSG(a_sf <= 3 && g_sf <= 7);
+	__ASSERT_NO_MSG(a_sf < IIM42652_ACCEL_FS_COUNT &&
+			g_sf < IIM42652_GYRO_FS_COUNT);
 
 	result = inv_spi_read(&cfg->spi, REG_ACCEL_CONFIG0, &databuf, 1);
 	if (result) {

--- a/extra/drivers/sensor/iim42652/iim42652_setup.c
+++ b/extra/drivers/sensor/iim42652/iim42652_setup.c
@@ -47,7 +47,7 @@ int iim42652_set_fs(const struct device *dev, uint16_t a_sf, uint16_t g_sf)
 	if (result) {
 		return result;
 	}
-	LOG_INF("ACCEL_CONFIG0 written = 0x%02X (FS_SEL=%u)", databuf, a_sf);
+	LOG_DBG("ACCEL_CONFIG0 written = 0x%02X (FS_SEL=%u)", databuf, a_sf);
 
 	result = inv_spi_read(&cfg->spi, REG_GYRO_CONFIG0, &databuf, 1);
 
@@ -63,7 +63,7 @@ int iim42652_set_fs(const struct device *dev, uint16_t a_sf, uint16_t g_sf)
 	if (result) {
 		return result;
 	}
-	LOG_INF("GYRO_CONFIG0 written = 0x%02X (FS_SEL=%u)", databuf, g_sf);
+	LOG_DBG("GYRO_CONFIG0 written = 0x%02X (FS_SEL=%u)", databuf, g_sf);
 
 	return 0;
 }

--- a/extra/drivers/sensor/iim42652/iim42652_setup.c
+++ b/extra/drivers/sensor/iim42652/iim42652_setup.c
@@ -26,15 +26,26 @@ int iim42652_set_fs(const struct device *dev, uint16_t a_sf, uint16_t g_sf)
 	uint8_t databuf;
 	int result;
 
+	/* Validate FS_SEL indices: accel uses bit[7:5] over 4 codes (0..3),
+	 * gyro uses bit[7:5] over 8 codes (0..7). */
+	if (a_sf > 3 || g_sf > 7) {
+		LOG_ERR("Invalid FS_SEL a=%u g=%u", a_sf, g_sf);
+		return -EINVAL;
+	}
+	__ASSERT_NO_MSG(a_sf <= 3 && g_sf <= 7);
+
 	result = inv_spi_read(&cfg->spi, REG_ACCEL_CONFIG0, &databuf, 1);
 	if (result) {
 		return result;
 	}
 	databuf &= ~BIT_ACCEL_FSR;
-
-	databuf |= a_sf;
+	databuf |= ((uint8_t)a_sf << SHIFT_ACCEL_FS_SEL) & BIT_ACCEL_FSR;
 
 	result = inv_spi_single_write(&cfg->spi, REG_ACCEL_CONFIG0, &databuf);
+	if (result) {
+		return result;
+	}
+	LOG_INF("ACCEL_CONFIG0 written = 0x%02X (FS_SEL=%u)", databuf, a_sf);
 
 	result = inv_spi_read(&cfg->spi, REG_GYRO_CONFIG0, &databuf, 1);
 
@@ -43,13 +54,14 @@ int iim42652_set_fs(const struct device *dev, uint16_t a_sf, uint16_t g_sf)
 	}
 
 	databuf &= ~BIT_GYRO_FSR;
-	databuf |= g_sf;
+	databuf |= ((uint8_t)g_sf << SHIFT_GYRO_FS_SEL) & BIT_GYRO_FSR;
 
 	result = inv_spi_single_write(&cfg->spi, REG_GYRO_CONFIG0, &databuf);
 
 	if (result) {
 		return result;
 	}
+	LOG_INF("GYRO_CONFIG0 written = 0x%02X (FS_SEL=%u)", databuf, g_sf);
 
 	return 0;
 }


### PR DESCRIPTION
iim42652_set_fs() was OR-ing the FS_SEL value into bit[1:0] of ACCEL_CONFIG0/GYRO_CONFIG0 without the bit-5 shift, so the FSR bit field [7:5] kept its reset default. As a result the chip ran at +/-16G / +/-2000 DPS regardless of the application's +/-2G / +/-1000 DPS intent. SI output happened to remain correct only because the hard-coded sensitivity in iim42652_init() (14 - 3 -> shift 11, gyro table [3] -> 164) coincidentally matched the default hardware range.

Changes:
- iim42652_set_fs(): shift FS_SEL into bit[7:5] using existing SHIFT_*_FS_SEL macros; reject out-of-range indices with -EINVAL; add LOG_INF per axis showing the byte that was written.
- Rewrite iim42652_gyro_sensitivity_x10[] to 8 entries indexed by GYRO_FS_SEL register code (was 4 entries in reverse order).
- Add update_accel_sensitivity()/update_gyro_sensitivity() helpers; accel formula is shift = 11 + sf_idx.
- iim42652_init() and iim42652_attr_set(FULL_SCALE) use the helpers so cached sensitivity follows the configured FS.
- iim42652_attr_set() returns -EBUSY for ODR/FS changes while the sensor is running, since the driver only writes those registers during turn_on_sensor().


## Close Ticket

AMRSW-2862

## Description

The IIM-42652 Zephyr driver has a bit-field shift bug in iim42652_set_fs(): the full-scale select value is OR'd directly into the register without left-shifting by 5, so it lands in bits [1:0] instead of the required bits [7:5] (BIT_ACCEL_FSR = 0xE0). Consequently, the FS_SEL field always stays at the power-on default 000, locking the hardware at ±16 G / ±2000 DPS regardless of what the application requests (±2 G / ±1000 DPS).

A second issue compounds this: attr_set(FULL_SCALE) never updates the sensitivity constants (accel_sensitivity_shift, gyro_sensitivity_x10), which are hard-coded once in iim42652_init() at indices matching ±16 G / ±2000 DPS. By coincidence, this makes the SI conversion internally consistent with the actual (wrong) hardware range, so the output values are numerically correct—but the effective resolution and quantization noise are 8× / 2× worse than intended, and all application-level assumptions about dynamic range are invalid.

## Testing

AMR used: PACO v71es007.

Tested on `dev/AMRSW-2870-imu-auto-calibration`, which is stacked on this PR and adds a diagnostic `imu regdump` Zephyr shell command. The diagnostic shell was only used to read back the IIM-42652 registers written by this PR's `iim42652_set_fs()` path.

### Register readback

```text
$ imu regdump
IIM-42652 register dump (sensor running, no power-cycle):
  WHO_AM_I            (B0 0x75) = 0x6F
  PWR_MGMT0           (B0 0x4E) = 0x0F
  GYRO_CONFIG0        (B0 0x4F) = 0x29
  ACCEL_CONFIG0       (B0 0x50) = 0x69
  SELF_TEST_CONFIG    (B0 0x70) = 0x00
  OFFSET_USER0..8     = all 0x00
  raw accel burst (FSR=2g, 16384 LSB/g):
    X=4 (0.0002 g), Y=-30 (-0.0018 g), Z=-15902 (-0.9706 g)
```

Decoded:

- `ACCEL_CONFIG0 = 0x69`
  - `ACCEL_CONFIG0[7:5] = 0b011` → ±2g
  - `ACCEL_CONFIG0[3:0] = 0b1001` → 50 Hz
  - Confirms the requested `ACCEL_FS_2G` value is now written into the correct bit field (was stuck at reset `000` = ±16g before this PR).
- `GYRO_CONFIG0 = 0x29`
  - `GYRO_CONFIG0[7:5] = 0b001` → ±1000 dps
  - `GYRO_CONFIG0[3:0] = 0b1001` → 50 Hz
  - Confirms the requested gyro FS value is also written into the correct bit field (was stuck at reset `000` = ±2000 dps before this PR).
- The `imu regdump` decoder selected `16384 LSB/g`, matching the ±2g sensitivity table entry added by this PR.
- `OFFSET_USER0..8 = all 0x00`, so the raw `Z = -0.9706 g` reading was not affected by hardware offset calibration; it is the unmodified static reading at the corrected ±2g range.

### Build

`make firmware` passes.

## Visualization

_If applicable, add some screenshots to demonstrate your changes._

## Dependent PRs (if any)

_If applicable, add the links to submodule PRs related to this PR_
