### PR TITLE
AMRSW-2870 IMU manual calibration shell (dry-run) behind LEXXHARD_IMU_CALIBRATION

### DIFF
--- a/lexxpluss_apps/CMakeLists.txt
+++ b/lexxpluss_apps/CMakeLists.txt
@@ -39,6 +39,10 @@ if(USE_TWO_STATE_KEY_SWITCH)
     add_definitions(-DUSE_TWO_STATE_KEY_SWITCH)
 endif()
 
+if(LEXXHARD_IMU_CALIBRATION)
+    add_definitions(-DLEXXHARD_IMU_CALIBRATION)
+endif()
+
 if(VERSION)
     add_definitions(-DVERSION=${VERSION})
 endif()

--- a/lexxpluss_apps/src/imu_calibration.cpp
+++ b/lexxpluss_apps/src/imu_calibration.cpp
@@ -39,9 +39,36 @@ namespace lexxhard::imu_calibration {
 
 namespace {
 
+/* State machine, with two intermediate states to make all shared-data
+ * writes single-writer:
+ *
+ *   IDLE / DONE / FAILED   - terminal-ish; shell may start a new run
+ *
+ *      shell CAS {IDLE,DONE,FAILED} -> STARTING
+ *      shell exclusively owns g_acc + g_diag (clears both)
+ *      shell release-store STARTING -> RUNNING
+ *
+ *   RUNNING                - fetcher exclusively writes g_acc; nobody
+ *                            writes g_diag
+ *
+ *      whoever CAS-wins RUNNING -> FINALIZING owns g_diag exclusively:
+ *        - fetcher hits N samples in feed_sample() -> finalize()
+ *        - shell timeout in cmd_calrun()
+ *      Winner writes g_diag, then release-store FINALIZING -> DONE/FAILED.
+ *      Loser of the CAS does nothing.
+ *
+ *   FINALIZING             - exclusive g_diag write phase; readers must
+ *                            spin until DONE/FAILED.
+ *
+ * feed_sample() only acts when state == RUNNING. It ignores STARTING and
+ * FINALIZING so the shell side has uncontended access to g_acc / g_diag
+ * during those phases.
+ */
 enum class state_t : int {
     IDLE = 0,
+    STARTING,
     RUNNING,
+    FINALIZING,
     DONE,
     FAILED,
 };
@@ -109,6 +136,17 @@ int16_t clamp_step(double s) {
 }
 
 void finalize() {
+    /* Claim exclusive g_diag write right via RUNNING -> FINALIZING CAS.
+     * If the shell's timeout path won the race we bail; whatever it wrote
+     * (or zeroed) into g_diag is now authoritative. */
+    int expected = static_cast<int>(state_t::RUNNING);
+    if (!g_state.compare_exchange_strong(
+            expected,
+            static_cast<int>(state_t::FINALIZING),
+            std::memory_order_acq_rel)) {
+        return;
+    }
+
     constexpr int N = N_SAMPLES;
     const double ax_mean = g_acc.sum_ax / N;
     const double ay_mean = g_acc.sum_ay / N;
@@ -323,29 +361,34 @@ int cmd_calrun(const struct shell *shell, size_t argc, char **argv) {
     ARG_UNUSED(argc);
     ARG_UNUSED(argv);
 
-    /* Accept restart from IDLE / DONE / FAILED; reject if RUNNING. */
-    auto try_acquire = []() -> bool {
+    /* Acquire phase: CAS {IDLE,DONE,FAILED} -> STARTING. While STARTING,
+     * feed_sample() bails out, so we have exclusive access to g_acc and
+     * g_diag and can reset them safely. */
+    auto try_acquire_starting = []() -> bool {
         for (auto from : {state_t::IDLE, state_t::DONE, state_t::FAILED}) {
             int expected = static_cast<int>(from);
             if (g_state.compare_exchange_strong(
                     expected,
-                    static_cast<int>(state_t::RUNNING),
+                    static_cast<int>(state_t::STARTING),
                     std::memory_order_acq_rel)) {
                 return true;
             }
         }
         return false;
     };
-    if (!try_acquire()) {
+    if (!try_acquire_starting()) {
         shell_error(shell, "Calibration already running. Wait for it to finish.");
         return 1;
     }
 
-    /* Reset accumulator. State has just transitioned to RUNNING, so the
-     * fetcher loop may already pass the gate; the first DRAIN_SAMPLES are
-     * discarded anyway. */
+    /* Single-writer phase: nobody else touches g_acc or g_diag. */
     g_acc = accumulator_t{};
     g_acc.drain_remaining = DRAIN_SAMPLES;
+    g_diag = diag_t{};  /* clear stale stats from previous run */
+
+    /* Release-store STARTING -> RUNNING. The fetcher's next acquire-load
+     * sees both the new state AND the cleared accumulator. */
+    g_state.store(static_cast<int>(state_t::RUNNING), std::memory_order_release);
 
     shell_print(shell,
                 "calrun: dry-run, collecting %d samples (~%d s @ 50 Hz). Keep robot static.",
@@ -361,16 +404,30 @@ int cmd_calrun(const struct shell *shell, size_t argc, char **argv) {
         k_msleep(POLL_INTERVAL_MS);
     }
 
-    if (g_state.load(std::memory_order_acquire) == static_cast<int>(state_t::RUNNING)) {
-        /* Timed out. Mark diag and transition to FAILED so future calls retry. */
-        g_diag.ever_ran = true;
-        g_diag.timeout = true;
-        g_diag.envelope_ok = false;
-        g_diag.motion_ok = false;
-        g_diag.final_state = state_t::FAILED;
-        g_diag.collected = g_acc.collected;
-        g_diag.fail_reason = "timeout (insufficient samples)";
-        g_state.store(static_cast<int>(state_t::FAILED), std::memory_order_release);
+    /* Timeout path. Try to win RUNNING -> FINALIZING; only the winner
+     * gets to write g_diag. If fetcher just finalized concurrently,
+     * we lose the CAS and its g_diag is authoritative. */
+    {
+        int expected = static_cast<int>(state_t::RUNNING);
+        if (g_state.compare_exchange_strong(
+                expected,
+                static_cast<int>(state_t::FINALIZING),
+                std::memory_order_acq_rel)) {
+            g_diag.ever_ran = true;
+            g_diag.timeout = true;
+            g_diag.envelope_ok = false;
+            g_diag.motion_ok = false;
+            g_diag.final_state = state_t::FAILED;
+            g_diag.collected = g_acc.collected;
+            g_diag.fail_reason = "timeout (insufficient samples)";
+            g_state.store(static_cast<int>(state_t::FAILED), std::memory_order_release);
+        } else {
+            /* Fetcher won the race. Wait briefly for it to publish DONE/FAILED. */
+            while (g_state.load(std::memory_order_acquire) ==
+                   static_cast<int>(state_t::FINALIZING)) {
+                k_yield();
+            }
+        }
     }
 
     print_diag(shell);

--- a/lexxpluss_apps/src/imu_calibration.cpp
+++ b/lexxpluss_apps/src/imu_calibration.cpp
@@ -1,0 +1,391 @@
+/*
+ * Copyright (c) 2026, LexxPluss Inc.
+ *
+ * Manual IMU calibration shell - DRY-RUN ONLY (PR #85).
+ *
+ * Behaviour summary (see imu_calibration.hpp for concurrency model):
+ *   `imu calrun`  - one-shot: drain transients, accumulate N_SAMPLES samples
+ *                   off the running IMU fetcher loop, finalize means / stds /
+ *                   would-write OFFSET_USER step values, run envelope + motion
+ *                   gates, print result. Never writes hardware.
+ *   `imu calinfo` - print the last calrun result plus the chip's current
+ *                   OFFSET_USER registers decoded into per-axis step / mG / dps.
+ *
+ * Algorithm is identical to the PACO-verified startup auto-cal v2; only the
+ * trigger has changed (boot path -> manual shell). The actual `OFFSET_USER`
+ * write moves to a follow-up PR (`imu calrun --write`).
+ */
+#include "imu_calibration.hpp"
+
+#ifdef LEXXHARD_IMU_CALIBRATION
+
+#include <algorithm>
+#include <atomic>
+#include <cmath>
+#include <cstdint>
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/shell/shell.h>
+
+#include "sensor/iim42652/iim42652_reg.h"
+#include "sensor/iim42652/iim42652_setup.h"
+
+LOG_MODULE_DECLARE(imu, CONFIG_SENSOR_LOG_LEVEL);
+
+namespace lexxhard::imu_calibration {
+
+namespace {
+
+enum class state_t : int {
+    IDLE = 0,
+    RUNNING,
+    DONE,
+    FAILED,
+};
+
+constexpr int N_SAMPLES = 200;           /* ~4 s @ 50 Hz, same as v2 */
+constexpr int DRAIN_SAMPLES = 5;         /* ~100 ms transient drain */
+constexpr int TIMEOUT_MS = 6000;         /* 4 s nominal + slack */
+constexpr int POLL_INTERVAL_MS = 50;
+
+constexpr double G_LOCAL = 9.80665;
+constexpr double PI_D = 3.14159265358979323846;
+constexpr double RAD_TO_DEG = 180.0 / PI_D;
+constexpr double ACCEL_STEP_MG = 0.5;            /* DS Sec.18, 0.5 mG/step */
+constexpr double GYRO_STEP_MDPS = 1000.0 / 32.0; /* 31.25 mdps/step */
+
+/* Gates - same as PACO-verified v2 (~3-5x static noise floor). */
+constexpr double ENV_AX_AY_MG_LIMIT = 50.0;
+constexpr double ENV_AZ_MG_LIMIT    = 100.0;
+constexpr double ENV_GYRO_DPS_LIMIT = 5.0;
+constexpr double MOTION_ACCEL_STD_MG = 5.0;
+constexpr double MOTION_GYRO_STD_DPS = 0.1;
+
+std::atomic<int> g_state{static_cast<int>(state_t::IDLE)};
+
+struct accumulator_t {
+    int drain_remaining;
+    int collected;
+    double sum_ax, sum_ay, sum_az;
+    double sum_ax2, sum_ay2, sum_az2;
+    double sum_gx, sum_gy, sum_gz;
+    double sum_gx2, sum_gy2, sum_gz2;
+};
+accumulator_t g_acc{};
+
+struct diag_t {
+    bool ever_ran;
+    state_t final_state;
+    int collected;
+    /* sensor frame means + stds */
+    double ax_bias_mg, ay_bias_mg, az_bias_mg;
+    double gx_bias_dps, gy_bias_dps, gz_bias_dps;
+    double az_target_mps2;
+    double ax_std_mg, ay_std_mg, az_std_mg;
+    double gx_std_dps, gy_std_dps, gz_std_dps;
+    /* would-write step values (NOT applied in dry-run) */
+    int16_t ax_step, ay_step, az_step;
+    int16_t gx_step, gy_step, gz_step;
+    /* gate outcomes */
+    bool envelope_ok;
+    bool motion_ok;
+    bool timeout;
+    const char *fail_reason;
+};
+diag_t g_diag{};
+
+double sv_to_d(const struct sensor_value *v) {
+    return static_cast<double>(v->val1) + static_cast<double>(v->val2) * 1e-6;
+}
+
+int16_t clamp_step(double s) {
+    long si = std::lround(s);
+    if (si < -2048) si = -2048;
+    if (si >  2047) si =  2047;
+    return static_cast<int16_t>(si);
+}
+
+void finalize() {
+    constexpr int N = N_SAMPLES;
+    const double ax_mean = g_acc.sum_ax / N;
+    const double ay_mean = g_acc.sum_ay / N;
+    const double az_mean = g_acc.sum_az / N;
+    const double gx_mean = g_acc.sum_gx / N;
+    const double gy_mean = g_acc.sum_gy / N;
+    const double gz_mean = g_acc.sum_gz / N;
+
+    auto var_of = [](double sum2, double mean, int n) {
+        return std::max(0.0, sum2 / n - mean * mean);
+    };
+    const double ax_std = std::sqrt(var_of(g_acc.sum_ax2, ax_mean, N));
+    const double ay_std = std::sqrt(var_of(g_acc.sum_ay2, ay_mean, N));
+    const double az_std = std::sqrt(var_of(g_acc.sum_az2, az_mean, N));
+    const double gx_std = std::sqrt(var_of(g_acc.sum_gx2, gx_mean, N));
+    const double gy_std = std::sqrt(var_of(g_acc.sum_gy2, gy_mean, N));
+    const double gz_std = std::sqrt(var_of(g_acc.sum_gz2, gz_mean, N));
+
+    /* az target sign derived from observed gravity, not hardcoded. */
+    const double az_target = (az_mean >= 0.0) ? +G_LOCAL : -G_LOCAL;
+
+    g_diag.az_target_mps2 = az_target;
+    g_diag.ax_bias_mg  = ax_mean / G_LOCAL * 1000.0;
+    g_diag.ay_bias_mg  = ay_mean / G_LOCAL * 1000.0;
+    g_diag.az_bias_mg  = (az_mean - az_target) / G_LOCAL * 1000.0;
+    g_diag.gx_bias_dps = gx_mean * RAD_TO_DEG;
+    g_diag.gy_bias_dps = gy_mean * RAD_TO_DEG;
+    g_diag.gz_bias_dps = gz_mean * RAD_TO_DEG;
+
+    g_diag.ax_std_mg = ax_std / G_LOCAL * 1000.0;
+    g_diag.ay_std_mg = ay_std / G_LOCAL * 1000.0;
+    g_diag.az_std_mg = az_std / G_LOCAL * 1000.0;
+    g_diag.gx_std_dps = gx_std * RAD_TO_DEG;
+    g_diag.gy_std_dps = gy_std * RAD_TO_DEG;
+    g_diag.gz_std_dps = gz_std * RAD_TO_DEG;
+
+    g_diag.ax_step = clamp_step(-g_diag.ax_bias_mg  / ACCEL_STEP_MG);
+    g_diag.ay_step = clamp_step(-g_diag.ay_bias_mg  / ACCEL_STEP_MG);
+    g_diag.az_step = clamp_step(-g_diag.az_bias_mg  / ACCEL_STEP_MG);
+    g_diag.gx_step = clamp_step(-g_diag.gx_bias_dps * 1000.0 / GYRO_STEP_MDPS);
+    g_diag.gy_step = clamp_step(-g_diag.gy_bias_dps * 1000.0 / GYRO_STEP_MDPS);
+    g_diag.gz_step = clamp_step(-g_diag.gz_bias_dps * 1000.0 / GYRO_STEP_MDPS);
+
+    g_diag.envelope_ok =
+        std::fabs(g_diag.ax_bias_mg)  <= ENV_AX_AY_MG_LIMIT &&
+        std::fabs(g_diag.ay_bias_mg)  <= ENV_AX_AY_MG_LIMIT &&
+        std::fabs(g_diag.az_bias_mg)  <= ENV_AZ_MG_LIMIT    &&
+        std::fabs(g_diag.gx_bias_dps) <= ENV_GYRO_DPS_LIMIT &&
+        std::fabs(g_diag.gy_bias_dps) <= ENV_GYRO_DPS_LIMIT &&
+        std::fabs(g_diag.gz_bias_dps) <= ENV_GYRO_DPS_LIMIT;
+    g_diag.motion_ok =
+        g_diag.ax_std_mg <= MOTION_ACCEL_STD_MG &&
+        g_diag.ay_std_mg <= MOTION_ACCEL_STD_MG &&
+        g_diag.az_std_mg <= MOTION_ACCEL_STD_MG &&
+        g_diag.gx_std_dps <= MOTION_GYRO_STD_DPS &&
+        g_diag.gy_std_dps <= MOTION_GYRO_STD_DPS &&
+        g_diag.gz_std_dps <= MOTION_GYRO_STD_DPS;
+    g_diag.timeout = false;
+    g_diag.collected = g_acc.collected;
+    g_diag.ever_ran = true;
+
+    state_t final_state;
+    if (g_diag.envelope_ok && g_diag.motion_ok) {
+        final_state = state_t::DONE;
+        g_diag.fail_reason = nullptr;
+    } else {
+        final_state = state_t::FAILED;
+        g_diag.fail_reason = !g_diag.envelope_ok ? "envelope (bias too large)"
+                                                 : "motion (std too large)";
+    }
+    g_diag.final_state = final_state;
+
+    /* Release store so shell's acquire load sees a fully written g_diag. */
+    g_state.store(static_cast<int>(final_state), std::memory_order_release);
+}
+
+}  /* anonymous namespace */
+
+void feed_sample(const struct sensor_value accel[3],
+                 const struct sensor_value gyro[3]) {
+    if (g_state.load(std::memory_order_acquire) != static_cast<int>(state_t::RUNNING)) {
+        return;
+    }
+    if (g_acc.drain_remaining > 0) {
+        --g_acc.drain_remaining;
+        return;
+    }
+    if (g_acc.collected >= N_SAMPLES) {
+        return;
+    }
+    const double ax = sv_to_d(&accel[0]);
+    const double ay = sv_to_d(&accel[1]);
+    const double az = sv_to_d(&accel[2]);
+    const double gx = sv_to_d(&gyro[0]);
+    const double gy = sv_to_d(&gyro[1]);
+    const double gz = sv_to_d(&gyro[2]);
+    g_acc.sum_ax += ax; g_acc.sum_ax2 += ax * ax;
+    g_acc.sum_ay += ay; g_acc.sum_ay2 += ay * ay;
+    g_acc.sum_az += az; g_acc.sum_az2 += az * az;
+    g_acc.sum_gx += gx; g_acc.sum_gx2 += gx * gx;
+    g_acc.sum_gy += gy; g_acc.sum_gy2 += gy * gy;
+    g_acc.sum_gz += gz; g_acc.sum_gz2 += gz * gz;
+    if (++g_acc.collected >= N_SAMPLES) {
+        finalize();
+    }
+}
+
+namespace {
+
+void print_diag(const struct shell *shell) {
+    if (!g_diag.ever_ran) {
+        shell_print(shell, "No calibration run yet. Run `imu calrun`.");
+        return;
+    }
+
+    const char *state_name =
+        g_diag.final_state == state_t::DONE   ? "DONE" :
+        g_diag.final_state == state_t::FAILED ? "FAILED" : "?";
+    shell_print(shell, "Last calrun: %s (collected %d / %d)",
+                state_name, g_diag.collected, N_SAMPLES);
+    if (g_diag.final_state != state_t::DONE) {
+        shell_print(shell, "  fail reason: %s",
+                    g_diag.fail_reason ? g_diag.fail_reason : "(none)");
+    }
+
+    shell_print(shell, "[Sensor frame] bias:");
+    shell_print(shell, "  accel mG:  ax=%+.2f ay=%+.2f az=%+.2f (az_target=%+.4f m/s^2)",
+                g_diag.ax_bias_mg, g_diag.ay_bias_mg, g_diag.az_bias_mg,
+                g_diag.az_target_mps2);
+    shell_print(shell, "  gyro  dps: gx=%+.4f gy=%+.4f gz=%+.4f",
+                g_diag.gx_bias_dps, g_diag.gy_bias_dps, g_diag.gz_bias_dps);
+    shell_print(shell, "[Sensor frame] std:");
+    shell_print(shell, "  accel mG:  ax=%.3f ay=%.3f az=%.3f",
+                g_diag.ax_std_mg, g_diag.ay_std_mg, g_diag.az_std_mg);
+    shell_print(shell, "  gyro  dps: gx=%.4f gy=%.4f gz=%.4f",
+                g_diag.gx_std_dps, g_diag.gy_std_dps, g_diag.gz_std_dps);
+
+    /* ROS-frame view: applies the firmware CAN transform (X<->Y swap +
+     * negate-all) AND the SCBDriver receiver's extra accel.y flip, so the
+     * numbers match what `/driver/internal/sensor_set/imu` publishes. */
+    const double ros_ax = -g_diag.ay_bias_mg;
+    const double ros_ay = +g_diag.ax_bias_mg;
+    const double ros_az = -g_diag.az_bias_mg;
+    const double ros_gx = -g_diag.gy_bias_dps;
+    const double ros_gy = -g_diag.gx_bias_dps;
+    const double ros_gz = -g_diag.gz_bias_dps;
+    shell_print(shell, "[ROS frame, /driver/internal/sensor_set/imu] bias:");
+    shell_print(shell, "  accel mG:  x=%+.2f y=%+.2f z=%+.2f", ros_ax, ros_ay, ros_az);
+    shell_print(shell, "  gyro  dps: x=%+.4f y=%+.4f z=%+.4f", ros_gx, ros_gy, ros_gz);
+
+    shell_print(shell, "Would-write OFFSET_USER step (DRY-RUN, NOT applied):");
+    shell_print(shell, "  gyro:  gx=%+5d gy=%+5d gz=%+5d",
+                g_diag.gx_step, g_diag.gy_step, g_diag.gz_step);
+    shell_print(shell,
+                "  accel: ax=%+5d ay=%+5d az=%+5d  (ax/ay would NOT be written "
+                "even with --write; six-face test pending)",
+                g_diag.ax_step, g_diag.ay_step, g_diag.az_step);
+
+    shell_print(shell, "Gates: envelope=%s motion=%s",
+                g_diag.envelope_ok ? "OK" : "FAIL",
+                g_diag.motion_ok   ? "OK" : "FAIL");
+}
+
+void print_current_offset(const struct shell *shell) {
+    const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(imu0));
+    if (!device_is_ready(dev)) {
+        shell_warn(shell, "Cannot read current OFFSET_USER: IMU device not ready");
+        return;
+    }
+    uint8_t buf[9];
+    int rc = iim42652_diag_read_regs(dev, BIT_BANK_SEL_4, REG_OFFSET_USER0, buf, 9);
+    if (rc) {
+        shell_warn(shell, "Read OFFSET_USER0..8 failed rc=%d", rc);
+        return;
+    }
+    auto unpack12 = [](uint8_t lo_byte, uint8_t high_nibble) -> int16_t {
+        uint16_t u = (static_cast<uint16_t>(high_nibble & 0x0F) << 8) | lo_byte;
+        if (u & 0x800) {
+            u |= 0xF000;  /* sign-extend 12-bit -> 16-bit */
+        }
+        return static_cast<int16_t>(u);
+    };
+    /* DS Sec.18 OFFSET_USER packing (verified on PACO 2026-05-15 with
+     * az=-56 step -> bytes 00,00,00,00,00,00,00,F0,C8). */
+    const int16_t gx = unpack12(buf[0], (buf[1] >> 4) & 0x0F);
+    const int16_t gy = unpack12(buf[2],  buf[1]       & 0x0F);
+    const int16_t gz = unpack12(buf[3], (buf[4] >> 4) & 0x0F);
+    const int16_t ax = unpack12(buf[5],  buf[4]       & 0x0F);
+    const int16_t ay = unpack12(buf[6], (buf[7] >> 4) & 0x0F);
+    const int16_t az = unpack12(buf[8],  buf[7]       & 0x0F);
+
+    shell_print(shell, "Current OFFSET_USER (raw bytes 0..8):");
+    shell_print(shell, "  %02X %02X %02X %02X %02X %02X %02X %02X %02X",
+                buf[0], buf[1], buf[2], buf[3], buf[4],
+                buf[5], buf[6], buf[7], buf[8]);
+    shell_print(shell, "Current OFFSET_USER (decoded, sensor frame):");
+    shell_print(shell,
+                "  gyro:  gx=%+5d (%+.3f dps)  gy=%+5d (%+.3f dps)  gz=%+5d (%+.3f dps)",
+                gx, gx * (GYRO_STEP_MDPS / 1000.0),
+                gy, gy * (GYRO_STEP_MDPS / 1000.0),
+                gz, gz * (GYRO_STEP_MDPS / 1000.0));
+    shell_print(shell,
+                "  accel: ax=%+5d (%+.2f mG)  ay=%+5d (%+.2f mG)  az=%+5d (%+.2f mG)",
+                ax, ax * ACCEL_STEP_MG,
+                ay, ay * ACCEL_STEP_MG,
+                az, az * ACCEL_STEP_MG);
+}
+
+}  /* anonymous namespace */
+
+int cmd_calrun(const struct shell *shell, size_t argc, char **argv) {
+    ARG_UNUSED(argc);
+    ARG_UNUSED(argv);
+
+    /* Accept restart from IDLE / DONE / FAILED; reject if RUNNING. */
+    auto try_acquire = []() -> bool {
+        for (auto from : {state_t::IDLE, state_t::DONE, state_t::FAILED}) {
+            int expected = static_cast<int>(from);
+            if (g_state.compare_exchange_strong(
+                    expected,
+                    static_cast<int>(state_t::RUNNING),
+                    std::memory_order_acq_rel)) {
+                return true;
+            }
+        }
+        return false;
+    };
+    if (!try_acquire()) {
+        shell_error(shell, "Calibration already running. Wait for it to finish.");
+        return 1;
+    }
+
+    /* Reset accumulator. State has just transitioned to RUNNING, so the
+     * fetcher loop may already pass the gate; the first DRAIN_SAMPLES are
+     * discarded anyway. */
+    g_acc = accumulator_t{};
+    g_acc.drain_remaining = DRAIN_SAMPLES;
+
+    shell_print(shell,
+                "calrun: dry-run, collecting %d samples (~%d s @ 50 Hz). Keep robot static.",
+                N_SAMPLES, (N_SAMPLES + DRAIN_SAMPLES) / 50);
+
+    const int64_t deadline = k_uptime_get() + TIMEOUT_MS;
+    while (k_uptime_get() < deadline) {
+        int s = g_state.load(std::memory_order_acquire);
+        if (s == static_cast<int>(state_t::DONE) ||
+            s == static_cast<int>(state_t::FAILED)) {
+            break;
+        }
+        k_msleep(POLL_INTERVAL_MS);
+    }
+
+    if (g_state.load(std::memory_order_acquire) == static_cast<int>(state_t::RUNNING)) {
+        /* Timed out. Mark diag and transition to FAILED so future calls retry. */
+        g_diag.ever_ran = true;
+        g_diag.timeout = true;
+        g_diag.envelope_ok = false;
+        g_diag.motion_ok = false;
+        g_diag.final_state = state_t::FAILED;
+        g_diag.collected = g_acc.collected;
+        g_diag.fail_reason = "timeout (insufficient samples)";
+        g_state.store(static_cast<int>(state_t::FAILED), std::memory_order_release);
+    }
+
+    print_diag(shell);
+    return g_diag.final_state == state_t::DONE ? 0 : 1;
+}
+
+int cmd_calinfo(const struct shell *shell, size_t argc, char **argv) {
+    ARG_UNUSED(argc);
+    ARG_UNUSED(argv);
+    print_diag(shell);
+    shell_print(shell, "");
+    print_current_offset(shell);
+    return 0;
+}
+
+}  /* namespace lexxhard::imu_calibration */
+
+#endif  /* LEXXHARD_IMU_CALIBRATION */

--- a/lexxpluss_apps/src/imu_calibration.hpp
+++ b/lexxpluss_apps/src/imu_calibration.hpp
@@ -7,15 +7,21 @@
  * feed_sample() collapses to a no-op so the IMU fetcher loop is unchanged.
  * When on, the shell registers `imu calrun` and `imu calinfo` subcommands.
  *
- * Concurrency model:
- *   - The IMU fetcher thread (imu_controller.cpp) calls feed_sample() once
- *     per sample. Only that thread mutates the accumulator.
- *   - The shell thread (cmd_calrun) initiates a run via an atomic state
- *     transition IDLE -> RUNNING, then polls the same atomic. It never
- *     touches the accumulator or the sensor directly.
- *   - finalize() runs on the fetcher thread when the sample count reaches
- *     N_SAMPLES, then publishes the final state with a release store so
- *     the shell sees a consistent g_diag on its next acquire load.
+ * Concurrency model (state machine, see imu_calibration.cpp for details):
+ *
+ *   IDLE/DONE/FAILED   shell CAS -> STARTING
+ *   STARTING           shell exclusively writes g_acc + g_diag, then
+ *                      release-store -> RUNNING
+ *   RUNNING            fetcher exclusively writes g_acc via feed_sample()
+ *   FINALIZING         whoever wins RUNNING -> FINALIZING CAS exclusively
+ *                      writes g_diag (fetcher in finalize(), or shell on
+ *                      timeout). Loser does nothing.
+ *   DONE/FAILED        terminal; g_diag is stable and safe to read after
+ *                      an acquire-load observes one of these.
+ *
+ * feed_sample() only acts when state == RUNNING; STARTING and FINALIZING
+ * make it bail, so the shell side has uncontended access to shared data
+ * during those phases.
  */
 #pragma once
 

--- a/lexxpluss_apps/src/imu_calibration.hpp
+++ b/lexxpluss_apps/src/imu_calibration.hpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2026, LexxPluss Inc.
+ *
+ * Manual IMU calibration shell (PR #85, dry-run).
+ *
+ * Gated by LEXXHARD_IMU_CALIBRATION (default OFF). When the flag is off,
+ * feed_sample() collapses to a no-op so the IMU fetcher loop is unchanged.
+ * When on, the shell registers `imu calrun` and `imu calinfo` subcommands.
+ *
+ * Concurrency model:
+ *   - The IMU fetcher thread (imu_controller.cpp) calls feed_sample() once
+ *     per sample. Only that thread mutates the accumulator.
+ *   - The shell thread (cmd_calrun) initiates a run via an atomic state
+ *     transition IDLE -> RUNNING, then polls the same atomic. It never
+ *     touches the accumulator or the sensor directly.
+ *   - finalize() runs on the fetcher thread when the sample count reaches
+ *     N_SAMPLES, then publishes the final state with a release store so
+ *     the shell sees a consistent g_diag on its next acquire load.
+ */
+#pragma once
+
+#include <zephyr/drivers/sensor.h>
+
+#ifdef LEXXHARD_IMU_CALIBRATION
+
+#include <zephyr/shell/shell.h>
+
+namespace lexxhard::imu_calibration {
+
+void feed_sample(const struct sensor_value accel[3],
+                 const struct sensor_value gyro[3]);
+
+int cmd_calrun(const struct shell *shell, size_t argc, char **argv);
+int cmd_calinfo(const struct shell *shell, size_t argc, char **argv);
+
+}  // namespace lexxhard::imu_calibration
+
+#else  /* LEXXHARD_IMU_CALIBRATION */
+
+namespace lexxhard::imu_calibration {
+
+inline void feed_sample(const struct sensor_value[3],
+                        const struct sensor_value[3]) {}
+
+}  // namespace lexxhard::imu_calibration
+
+#endif  /* LEXXHARD_IMU_CALIBRATION */

--- a/lexxpluss_apps/src/imu_controller.cpp
+++ b/lexxpluss_apps/src/imu_controller.cpp
@@ -33,6 +33,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 #include "common.hpp"
+#include "imu_calibration.hpp"
 #include "imu_controller.hpp"
 #include "runaway_detector.hpp"
 #include "sensor/iim42652/iim42652_reg.h"
@@ -127,6 +128,8 @@ public:
 
                     sensor_channel_get(dev, SENSOR_CHAN_ACCEL_XYZ, accel);
                     sensor_channel_get(dev, SENSOR_CHAN_GYRO_XYZ, gyro);
+
+                    imu_calibration::feed_sample(accel, gyro);
 
                     //sensor -x is system y, sensor -y is systemx, sensor z is system z
                     accel_data[1] = - accel_value_to_int16_t(&accel[0]);
@@ -354,6 +357,12 @@ int regdump(const struct shell *shell, size_t argc, char **argv)
 SHELL_STATIC_SUBCMD_SET_CREATE(sub,
     SHELL_CMD(info, NULL, "IMU information", info),
     SHELL_CMD(regdump, NULL, "IIM-42652 register dump (WHO_AM_I, configs, OFFSET_USER, raw ACCEL/GYRO/TEMP)", regdump),
+#ifdef LEXXHARD_IMU_CALIBRATION
+    SHELL_CMD(calrun,  NULL, "Manual calibration dry-run: compute biases + would-write step values; OFFSET_USER NOT touched",
+              lexxhard::imu_calibration::cmd_calrun),
+    SHELL_CMD(calinfo, NULL, "Show last calrun result + current OFFSET_USER decode",
+              lexxhard::imu_calibration::cmd_calinfo),
+#endif
     SHELL_SUBCMD_SET_END
 );
 SHELL_CMD_REGISTER(imu, &sub, "IMU commands", NULL);


### PR DESCRIPTION
## Status

PACO `v71es007` dry-run verified. v710es04 pending (machine currently offline). Ready for code review; will mark ready-for-merge after v710es04 smoke test.

## Summary

Manual IMU calibration shell — **dry-run only**. Algorithm is identical to the PACO-verified startup auto-cal v2; the only change is the trigger has been moved from the boot path to a shell command. No `OFFSET_USER` writes happen in this PR (those move to PR #86, `imu calrun --write`).

**Base:** `dev/AMRSW-2870-imu-auto-calibration` (PR #84, driver hardening + OFFSET_USER API + regdump). This PR is stacked on PR #84 and should be merged after it.

**Default behaviour:** new CMake flag `LEXXHARD_IMU_CALIBRATION` is **OFF**. With the flag off, this PR introduces zero runtime changes (`feed_sample()` collapses to an inline no-op; the new shell subcommands are not registered). Verified on hardware — see *Hardware verification* below.

## Why dry-run + manual trigger

Calibration in the boot path can block SCB main power / SSH / DFU if it misbehaves (SWD recovery was required on 2026-05-20). A default-off feature flag bounds the *default* risk; a manual-only invocation also bounds the *worst-case* risk — even if someone turns the flag on in production, the algorithm can never reach the boot path by mistake.

This PR is the dry-run; PR #86 will add `--write`.

## Two new shell subcommands (flag-on only)

```text
imu calrun
```
Drain ~100 ms of transients, accumulate 200 samples from the running IMU fetcher loop, compute per-axis mean / std / would-write `OFFSET_USER` step values, run envelope + motion gates, print result. Does **not** call `iim42652_set_offset_user()`. Blocks the shell for ~4 s while collecting.

```text
imu calinfo
```
Print the last `calrun` result + read back the chip's current `OFFSET_USER0..8` and decode into per-axis step / mdps / mG. Lets you confirm repeatability across reboots without re-running cal.

Both print the result in **two frames**:
- Sensor frame (raw IMU axes)
- ROS frame as published on `/driver/internal/sensor_set/imu`, applying both the firmware CAN transform (X↔Y swap + negate-all) **and** the SCBDriver receiver's extra `accel.y` flip — so the numbers correlate directly with rosbag analysis.

## Concurrency model

The fetcher thread is the sole writer of the accumulator. The shell thread initiates a run via an atomic state transition `IDLE → RUNNING`, polls the same atomic, and reads `g_diag` only after observing `DONE` / `FAILED`. `finalize()` publishes the final state with a release store so the shell's acquire load sees a consistent `g_diag`.

The shell **never** calls `sensor_sample_fetch()` itself — the main publish loop keeps running throughout cal, so the `/driver/internal/sensor_set/imu` topic stream is not interrupted. This is the design the 2026-05-20 retro identified as race-safe.

## Algorithm 

| | |
|---|---|
| Samples | 200 (~4 s @ 50 Hz) |
| Transient drain | ~100 ms (5 samples) |
| Timeout | 6 s |
| Envelope gate | `\|ax/ay\| ≤ 50 mG`, `\|az_resid\| ≤ 100 mG`, `\|gyro\| ≤ 5 dps` |
| Motion gate | accel std ≤ 5 mG, gyro std ≤ 0.1 dps (~3–5× PACO static noise floor) |
| Step units | accel 0.5 mG/step, gyro 1/32 dps/step |
| `az_target` | `sign(az_mean) * G_LOCAL` (observed, not hardcoded) |

The PACO v2 5-reboot repeatability numbers (`az ≈ −2.92 mG`, gyro three-axis within `±0.05 dps`) carry over because only the trigger changed. Verified on hardware below.

## Build

```
flag OFF: FLASH 75.25%   (identical to PR #84 baseline — inline no-op compiles to nothing)
flag ON:  FLASH 76.91%   +4352 B
          RAM   44.65%   +256 B
```

flag-on build uses a local (uncommitted) Makefile target:

```make
.PHONY: firmware_calibration
firmware_calibration:
	$(RUNNER) west zephyr-export
	$(RUNNER) west build -b lexxpluss_scb lexxpluss_apps -- -DLEXXHARD_IMU_CALIBRATION=1 -DBOARD_ROOT=/${WORKDIR}/extra -DZEPHYR_EXTRA_MODULES=/${WORKDIR}/extra -DVERSION=${VERSION}
	mv build/zephyr/zephyr.signed.bin out/zephyr_calibration.signed.bin
	mv build/zephyr/zephyr.signed.confirmed.bin out/zephyr_calibration.signed.confirmed.bin
```

This avoids the common `-D` flag being forgotten on the command line. Whether to land this target in the repo is open — current preference is to keep it out of the PR until we want a documented flag-on build path.

## Hardware verification — PACO 2026-05-26

Two builds flashed in sequence on PACO `v71es007` via Docker DFU over CAN.

### flag OFF (default `make firmware`)

| Check | PR #84 baseline | PR #85 flag-off | gate |
|---|---|---|---|
| `imu` subcommands | info/regdump | info/regdump | ✓ no calrun/calinfo |
| FLASH | 75.25% | 75.25% | ✓ identical |
| `imu regdump` | `OFFSET_USER0..8=0`, configs match | same | ✓ |
| 9 s `az residual` | −31.78 mG | −31.43 mG | ✓ Δ +0.35 mG (noise) |
| `az_std` | 1.152 mG | 1.135 mG | ✓ |
| Topic rate | 49.31 Hz | 49.31 Hz | ✓ |

Behaviorally indistinguishable from PR #84 — flag-off truly is a no-op.

### flag ON (`-DLEXXHARD_IMU_CALIBRATION=1`)

`strings build/zephyr/zephyr.elf` shows `cmd_calrun`, `cmd_calinfo`, and help text "Manual calibration dry-run: ... OFFSET_USER NOT touched". CMakeCache: `LEXXHARD_IMU_CALIBRATION:UNINITIALIZED=1`.

**`imu calrun` single-shot output (iter 1):**

```text
Last calrun: DONE (collected 200 / 200)
[Sensor frame] bias:
  accel mG:  ax=-3.84 ay=+1.16 az=+31.27 (az_target=-9.8066 m/s^2)
  gyro  dps: gx=-0.1952 gy=+0.0108 gz=+0.3478
[Sensor frame] std:
  accel mG:  ax=0.693 ay=0.513 az=1.074
  gyro  dps: gx=0.0365 gy=0.0354 gz=0.0294
[ROS frame, /driver/internal/sensor_set/imu] bias:
  accel mG:  x=-1.16 y=-3.84 z=-31.27
  gyro  dps: x=-0.0108 y=+0.1952 z=-0.3478
Would-write OFFSET_USER step (DRY-RUN, NOT applied):
  gyro:  gx=   +6 gy=   +0 gz=  -11
  accel: ax=   +8 ay=   -2 az=  -63  (ax/ay would NOT be written even with --write; six-face test pending)
Gates: envelope=OK motion=OK
```

**3-iter idempotency:**

| iter | sensor az (mG) | sensor gz (dps) | Would-write step | Gates |
|---|---|---|---|---|
| 1 | +31.27 | +0.3478 | `gx=+6 gy=0 gz=-11 ax=+8 ay=-2 az=-63` | OK/OK |
| 2 | +31.28 | +0.3491 | `gx=+6 gy=0 gz=-11 ax=+8 ay=-2 az=-63` | OK/OK |
| 3 | +31.12 | +0.3446 | `gx=+6 gy=0 gz=-11 ax=+8 ay=-2 az=-62` | OK/OK |

- gx/gy/gz/ax/ay step zero jitter across 3 iterations; `az_step` 1 LSB jitter (consistent with PACO v2 boot-path repeatability).
- Sensor-frame bias estimates consistent to 0.2 mG / 0.005 dps across iterations.
- `imu regdump` after each iteration: `OFFSET_USER0..8 = 0x00` — dry-run never writes hardware.

**Race-free verification (the key 2026-05-20 retro design check):**

A 15 s rosbag covering the calrun window:

| | |
|---|---|
| samples | 728 |
| duration | 14.74 s |
| mean rate | 49.31 Hz |
| median inter-sample gap | 20.03 ms (perfect 50 Hz period) |
| max gap | 34.05 ms at t=12.03 s (~6 s **after** calrun finished — unrelated) |
| gaps > 50 ms | 0 / 727 |
| gaps > 100 ms | 0 / 727 |

The main IMU loop kept publishing throughout calrun; the accumulator consumes as a side-channel without grabbing `int_flag` or calling `sensor_sample_fetch()` from the shell thread.

Compared to the PACO v2 boot-path numbers (`gz_step=-10..-11`, `az_step=-49..-50`), today's `az_step` is `-62..-63` because the current static bias is ~-31 mG vs ~-28 mG at v2 time — the compensation tracks the live bias, not a regression in the dry-run path.

## Files

| File | Why |
|---|---|
| `lexxpluss_apps/CMakeLists.txt` | Add `LEXXHARD_IMU_CALIBRATION` flag, matching the existing `ENABLE_INTERLOCK` / `USE_TWO_STATE_KEY_SWITCH` pattern |
| `lexxpluss_apps/src/imu_calibration.hpp` (new) | `feed_sample()` declaration (real when flag on, inline no-op when off) + shell command prototypes |
| `lexxpluss_apps/src/imu_calibration.cpp` (new) | State machine, accumulator, finalize, gates, `cmd_calrun`, `cmd_calinfo`. Entire file is wrapped in `#ifdef LEXXHARD_IMU_CALIBRATION` — empty TU when flag off |
| `lexxpluss_apps/src/imu_controller.cpp` | Three additions: include header, one-line `feed_sample(accel, gyro)` call in fetcher loop, two `SHELL_CMD` entries gated by `#ifdef` |

## Test plan

- [x] Builds clean **flag off** (`make firmware`, FLASH 75.25% identical to baseline)
- [x] Builds clean **flag on** (`make firmware_calibration` local target, FLASH 76.91%)
- [x] PACO v71es007 flag-off: behaves identically to PR #84 (subcommands, regdump, 9 s baseline)
- [x] PACO v71es007 flag-on: `imu calrun` returns sane bias/std/step within ~4 s
- [x] PACO v71es007 flag-on: IMU topic continues at ~50 Hz throughout `calrun` (race-free, max gap 34 ms outside the calrun window)
- [x] PACO v71es007 flag-on: `imu calinfo` decodes `OFFSET_USER` correctly (all-zero post-dry-run)
- [x] PACO v71es007 flag-on: 3-iter idempotency — would-write steps within 1 LSB; gates pass
- [ ] v710es04: same checks pass on a V7-production board (machine offline; will run when back in office)

## Follow-up PRs

- **PR #86** — `imu calrun --write` actually applies `OFFSET_USER` via `iim42652_set_offset_user()`. Opens after PR #85 merges.
- **boot confirmation PR (independent, smaller)** — Add `boot_write_img_confirmed()` in `<zephyr/dfu/mcuboot.h>` after app init + first main-loop publish. Decouples future `zephyr.signed.bin` testing from the cascading-reboot revert path observed in this PR's bring-up.
