### PR TITLE
feat(AMRSW-2112): powerline comm_mode DE control for charger heartbeat

### DIFF
--- a/extra/boards/arm/lexxpluss_scb/lexxpluss_scb.dts
+++ b/extra/boards/arm/lexxpluss_scb/lexxpluss_scb.dts
@@ -205,6 +205,10 @@
 			compatible = "gpio-pin";
 			gpios = <&gpioh 12 GPIO_ACTIVE_HIGH>;
 		};
+		comm_mode: comm_mode {
+			compatible = "gpio-pin";
+			gpios = <&gpioj 4 GPIO_ACTIVE_HIGH>;
+		};
 
 		/* Fan */
 		fan1: fan1 {
@@ -440,10 +444,6 @@
 		spare_gpio_4: spare_gpio_4 {
 			compatible = "gpio-pin";
 			gpios = <&gpioj 3 GPIO_ACTIVE_HIGH>;
-		};
-		spare_gpio_5: spare_gpio_5 {
-			compatible = "gpio-pin";
-			gpios = <&gpioj 4 GPIO_ACTIVE_HIGH>;
 		};
 		spare_gpio_6: spare_gpio_6 {
 			compatible = "gpio-pin";

--- a/lexxpluss_apps/src/board_controller.cpp
+++ b/lexxpluss_apps/src/board_controller.cpp
@@ -688,6 +688,13 @@ public:
         }
         uart_irq_rx_enable(dev);
 
+        gpio_dt_spec gpio_comm_mode_dev = GET_GPIO(comm_mode);
+        if (!gpio_is_ready_dt(&gpio_comm_mode_dev)) {
+            LOG_ERR("gpio_is_ready_dt of comm_mode Failed\n");
+            return;
+        }
+        gpio_pin_set_dt(&gpio_comm_mode_dev, 0);
+
         return;
     }
     bool is_docked() const {
@@ -813,8 +820,9 @@ private: // Thermistor side starts here.
             return;
         }
 
-        for (int i{0}; i < IRDA_DATA_LEN; ++i) {
-            uart_poll_out(dev, buf[i]);
+        if (!serial_write(buf, IRDA_DATA_LEN)) {
+            LOG_ERR("Failed to send heartbeat");
+            return;
         }
        
         LOG_DBG("Hearbeat Send\n");
@@ -845,6 +853,23 @@ private: // Thermistor side starts here.
                 }
             }
         }
+    }
+    bool serial_write(uint8_t const* buf, size_t len) {
+        gpio_dt_spec gpio_comm_mode_dev = GET_GPIO(comm_mode);
+        if (!gpio_is_ready_dt(&gpio_comm_mode_dev)) {
+            LOG_ERR("gpio_is_ready_dt of comm_mode Failed\n");
+            return false;
+        }
+
+        gpio_pin_set_dt(&gpio_comm_mode_dev, 1); // assert DE: switch PLC transceiver to TX
+        for (size_t i{0}; i < len; ++i) {
+            uart_poll_out(dev, buf[i]);
+        }
+        // Hold DE briefly so the final byte fully shifts out before returning to RX.
+        k_usleep(20);
+        gpio_pin_set_dt(&gpio_comm_mode_dev, 0); // deassert DE: back to RX
+
+        return true;
     }
 
     const device* dev{nullptr}; // UART device

--- a/lexxpluss_apps/src/main.cpp
+++ b/lexxpluss_apps/src/main.cpp
@@ -131,6 +131,9 @@ void init_gpio() {
     gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(eo_option_2), gpios);
     if (gpio_is_ready_dt(&gpio_dev))
         gpio_pin_configure_dt(&gpio_dev, GPIO_OUTPUT_LOW | GPIO_ACTIVE_HIGH);
+    gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(comm_mode), gpios);
+    if (gpio_is_ready_dt(&gpio_dev))
+        gpio_pin_configure_dt(&gpio_dev, GPIO_OUTPUT_LOW | GPIO_ACTIVE_HIGH);
     
     // Input
     gpio_dev = GPIO_DT_SPEC_GET(DT_NODELABEL(ps_sw_in), gpios);


### PR DESCRIPTION
## About
Adds half-duplex direction control for the powerline (PLC) charger
heartbeat link on the SCB side. Changes are limited to three files,
all comm_mode/DE related:

- `lexxpluss_scb.dts` — repurpose `spare_gpio_5` (PJ4) as `comm_mode`
- `main.cpp` — initialise `comm_mode` low at boot
- `board_controller.cpp` — `serial_write()` asserts `comm_mode` (DE)
  before the heartbeat TX burst and holds briefly after the burst
  before deasserting back to RX

## Validation
Verified on v71es007: SCB enters AUTO_CHARGE, charger heartbeat decodes
(rx_b=8 rx_d=1), BMU charges at ~8A. The brief post-burst DE hold is
backed by this on-vehicle validation rather than a strict
transmission-complete guarantee.

Note: v71es007 validation used a local test-only safety bypass build
because that vehicle lacks E-stop/safety lidar hardware. The release
build keeps normal safety logic and does not include any bypass. The
bypass is not part of this PR and must never be merged or tagged.

## Known pre-existing risk (out of scope)
`auto_charge_on` shell command (board_controller.cpp:1353) already
exists in prod — it is NOT introduced by this PR. It calls
`ac.set_enable(true)` directly, bypassing the AUTO_CHARGE state machine
and FET safety preconditions.
Recommend a separate ticket to guard or remove it from release builds.
Not touched here to keep the diff scoped to PLC comm.
