### PR TITLE
Feat/AMRSW 2903 software resume command

### DIFF
--- a/lexxpluss_apps/src/board_controller.cpp
+++ b/lexxpluss_apps/src/board_controller.cpp
@@ -1184,6 +1184,12 @@ public:
     bool is_wheel_poweroff() const {
         return wheel_poweroff;
     }
+    bool software_resume_from_ros() const {
+        return software_resume_request;
+    }
+    void consume_software_resume() {
+        software_resume_request = false;
+    }
 private:
     void reset_queue() {
         msg_rcv_pb msg;
@@ -1208,6 +1214,9 @@ private:
         if (auto_charge_request_enable != msg.ros_auto_charge_request_enable) {
             LOG_INF("ROS Auto Charge Request Enable: %d", msg.ros_auto_charge_request_enable);
         }
+        if (software_resume_request != msg.ros_software_resume_request) {
+            LOG_INF("ROS Software Resume Request: %d", msg.ros_software_resume_request);
+        }
 
         emergency_stop = msg.ros_emergency_stop;
         power_off = msg.ros_power_off;
@@ -1215,12 +1224,14 @@ private:
         wheel_poweroff = msg.ros_wheel_power_off;
         lockdown = msg.ros_lockdown;
         auto_charge_request_enable = msg.ros_auto_charge_request_enable;
+        software_resume_request = msg.ros_software_resume_request;
 
         // heartbeat is not timeout means heartbeat is detected
         heartbeat_detect |= !ros_heartbeat_timeout;
     }
     bool heartbeat_detect{false}, ros_heartbeat_timeout{false}, emergency_stop{true}, power_off{false},
-        wheel_poweroff{false}, lockdown{false}, auto_charge_request_enable{false};
+        wheel_poweroff{false}, lockdown{false}, auto_charge_request_enable{false},
+        software_resume_request{false};
 };
 
 class safety_lidar { // Variables Implemented
@@ -1605,6 +1616,14 @@ private:
                 else {
                     LOG_DBG("heartbeat NG\n");
                     set_new_state(POWER_STATE::STANDBY);
+                }
+            } else if (mbd.software_resume_from_ros()) {
+                mbd.consume_software_resume();
+                if (mbd.is_ready()) {
+                    LOG_DBG("software resume request\n");
+                    set_new_state(POWER_STATE::NORMAL);
+                } else {
+                    LOG_DBG("software resume request but heartbeat NG\n");
                 }
             } else if (should_manual_charge()) {
                 LOG_DBG("plugged to manual charger\n");

--- a/lexxpluss_apps/src/board_controller.cpp
+++ b/lexxpluss_apps/src/board_controller.cpp
@@ -1981,10 +1981,10 @@ private:
     }
     void try_resume() {
         if (mbd.is_ready()) {
-            LOG_DBG("heartbeat OK\n");
+            LOG_INF("heartbeat OK\n");
             set_new_state(POWER_STATE::NORMAL);
         } else {
-            LOG_DBG("heartbeat NG\n");
+            LOG_INF("heartbeat NG\n");
             set_new_state(POWER_STATE::STANDBY);
         }
     }

--- a/lexxpluss_apps/src/board_controller.cpp
+++ b/lexxpluss_apps/src/board_controller.cpp
@@ -1979,6 +1979,7 @@ private:
     }
     void try_resume() {
         if (mbd.is_ready()) {
+            LOG_DBG("heartbeat OK\n");
             set_new_state(POWER_STATE::NORMAL);
         } else {
             LOG_DBG("heartbeat NG\n");

--- a/lexxpluss_apps/src/board_controller.cpp
+++ b/lexxpluss_apps/src/board_controller.cpp
@@ -1820,6 +1820,7 @@ private:
         } break;
         case POWER_STATE::SUSPEND: {
             LOG_INF("enter SUSPEND\n");
+            mbd.consume_software_resume();
             psw.set_led(true);
             gpio_dt_spec gpio_dev = GET_GPIO(v_wheel);
             if (!gpio_is_ready_dt(&gpio_dev)) {
@@ -1831,6 +1832,7 @@ private:
         } break;
         case POWER_STATE::RESUME_WAIT: {
             LOG_INF("enter RESUME_WAIT\n");
+            mbd.consume_software_resume();
             rsw.set_led(true);
         } break;
         case POWER_STATE::AUTO_CHARGE: {

--- a/lexxpluss_apps/src/board_controller.cpp
+++ b/lexxpluss_apps/src/board_controller.cpp
@@ -1146,6 +1146,7 @@ public:
         power_off = false;
         wheel_poweroff = false;
         lockdown = false;
+        software_resume_request = false;
 
         reset_heartbeat();
         reset_queue();
@@ -1607,24 +1608,8 @@ private:
             } else if (mbd.is_dead()) {
                 LOG_DBG("mainboard is dead\n");
                 set_new_state(POWER_STATE::SUSPEND);
-            } else if (rsw.get_state() == resume_switch::STATE::PUSHED) {
-                LOG_DBG("resume switch pushed\n");
-                if (mbd.is_ready()) {
-                    LOG_DBG("heartbeat OK\n");
-                    set_new_state(POWER_STATE::NORMAL);
-                }
-                else {
-                    LOG_DBG("heartbeat NG\n");
-                    set_new_state(POWER_STATE::STANDBY);
-                }
-            } else if (mbd.software_resume_from_ros()) {
-                mbd.consume_software_resume();
-                if (mbd.is_ready()) {
-                    LOG_DBG("software resume request\n");
-                    set_new_state(POWER_STATE::NORMAL);
-                } else {
-                    LOG_DBG("software resume request but heartbeat NG\n");
-                }
+            } else if (is_resume_requested()) {
+                try_resume();
             } else if (should_manual_charge()) {
                 LOG_DBG("plugged to manual charger\n");
                 set_new_state(POWER_STATE::MANUAL_CHARGE);
@@ -1980,7 +1965,27 @@ private:
     bool should_manual_charge() {
         return mc.is_plugged();
     }
-    
+    bool is_resume_requested() {
+        if (rsw.get_state() == resume_switch::STATE::PUSHED) {
+            LOG_DBG("resume switch pushed\n");
+            return true;
+        }
+        if (mbd.software_resume_from_ros()) {
+            LOG_DBG("software resume request\n");
+            mbd.consume_software_resume();
+            return true;
+        }
+        return false;
+    }
+    void try_resume() {
+        if (mbd.is_ready()) {
+            set_new_state(POWER_STATE::NORMAL);
+        } else {
+            LOG_DBG("heartbeat NG\n");
+            set_new_state(POWER_STATE::STANDBY);
+        }
+    }
+
     power_switch psw;
     resume_switch rsw;
     key_switch ksw;

--- a/lexxpluss_apps/src/board_controller.hpp
+++ b/lexxpluss_apps/src/board_controller.hpp
@@ -43,6 +43,7 @@ struct msg_rcv_pb {
     bool ros_wheel_power_off;
     bool ros_lockdown;
     bool ros_auto_charge_request_enable;
+    bool ros_software_resume_request;
 } __attribute__((aligned(4)));
 
 

--- a/lexxpluss_apps/src/can_controller.cpp
+++ b/lexxpluss_apps/src/can_controller.cpp
@@ -90,6 +90,7 @@ public:
                 ros2board.wheel_power_off = false;
                 ros2board.lockdown = false;
                 ros2board.auto_charge_request_enable = true;
+                ros2board.software_resume_request = false;
                 heartbeat_timeout = false;
             }
 

--- a/lexxpluss_apps/src/can_controller.cpp
+++ b/lexxpluss_apps/src/can_controller.cpp
@@ -156,6 +156,7 @@ private:
         msg_board_to_pb.ros_wheel_power_off = ros2board.wheel_power_off;
         msg_board_to_pb.ros_lockdown = ros2board.lockdown;
         msg_board_to_pb.ros_auto_charge_request_enable = ros2board.auto_charge_request_enable;
+        msg_board_to_pb.ros_software_resume_request = ros2board.software_resume_request;
     }
     void publish_to_pb() {
         handler_to_pb();
@@ -164,7 +165,7 @@ private:
         }
     }
     msg_board board2ros{0};
-    msg_control ros2board{true, false, false, false, false, false};
+    msg_control ros2board{true, false, false, false, false, false, false};
     board_controller::msg_rcv_pb msg_board_to_pb{0};
     uint32_t prev_cycle_ros{0}, prev_cycle_send{0};
     bool heartbeat_timeout{false};

--- a/lexxpluss_apps/src/can_controller.hpp
+++ b/lexxpluss_apps/src/can_controller.hpp
@@ -66,6 +66,7 @@ struct msg_board {
 
 struct msg_control {
     bool emergency_stop, power_off, wheel_power_off, heart_beat, lockdown, auto_charge_request_enable;
+    bool software_resume_request;
 } __attribute__((aligned(4)));
 
 void init();

--- a/lexxpluss_apps/src/zcan_board.hpp
+++ b/lexxpluss_apps/src/zcan_board.hpp
@@ -121,6 +121,7 @@ public:
             msg.heart_beat = frame.data[3] & 0x01;
             msg.lockdown = (4 < frame.dlc) ? frame.data[4] & 0x01 : 0;  // this condition is for backward compatibility
             msg.auto_charge_request_enable = (5 < frame.dlc) ? frame.data[5] & 0x01 : 1;  // this condition is for backward compatibility
+            msg.software_resume_request = (6 < frame.dlc) ? frame.data[6] & 0x01 : 0;  // this condition is for backward compatibility
 
             if(prev_msg.emergency_stop != msg.emergency_stop) {
                 LOG_INF("Emergency Stop: %d", msg.emergency_stop);
@@ -145,6 +146,10 @@ public:
             if (prev_msg.auto_charge_request_enable != msg.auto_charge_request_enable) {
                 LOG_INF("Auto Charge Request Enable: %d", msg.auto_charge_request_enable);
                 prev_msg.auto_charge_request_enable = msg.auto_charge_request_enable;
+            }
+            if (prev_msg.software_resume_request != msg.software_resume_request) {
+                LOG_INF("Software Resume Request: %d", msg.software_resume_request);
+                prev_msg.software_resume_request = msg.software_resume_request;
             }
 
             while (k_msgq_put(&can_controller::msgq_control, &msg, K_NO_WAIT) != 0)


### PR DESCRIPTION
## Close Ticket
AMRSW-2903

## Description
Adds software resume request handling via CAN 0x20F frame.

Previously, the AMR could only resume from `RESUME_WAIT` state via the
physical resume switch (3-second press). This PR adds a new CAN field
(`data[6] bit0`, DLC=7) so that LexxAuto can trigger resume
programmatically from ROS.

Changes:
- `zcan_board.hpp`: Parse `software_resume_request` from `data[6] bit0`
  with backward-compatibility guard (`6 < frame.dlc`)
- `can_controller.hpp/cpp`: Add `software_resume_request` field to
  `msg_control`, propagate through `handler_to_pb()`
- `board_controller.hpp/cpp`: Add `software_resume_from_ros()` /
  `consume_software_resume()` accessors; refactor `RESUME_WAIT` branch
  into `is_resume_requested()` + `try_resume()` to unify physical switch
  and software resume triggers

## Testing
AMR used: v71004

- [x] V1: `control/request_resume` sends `0x20F data[6]bit0=1`
- [x] V2: RESUME_WAIT → NORMAL (happy path)
- [x] V3a: Software resume triggers NORMAL without physical button
- [ ] V3b — N/A (physical button alone; stable RESUME_WAIT not reproducible without grip error — see AMRSW-2892)
- [ ] V3c — N/A (simultaneous physical + software resume; same constraint as V3b)
- [x] V4a: Continuous bit=1 causes transition exactly once (consume logic)
- [ ] V4b — N/A (cross-cycle risk; scbdriver overwrites resume=0 immediately; verified by V2 log + code review)
- [ ] V5 — N/A (heartbeat stop = scbdriver stop = system stop; verified by code review)
- [ ] V6 — N/A (RESUME_WAIT is ~20ms transient; not reliably reproducible in assembled system)
- [x] V7: Resume ignored while EMS asserted (verified with physical EMS button)
- [ ] V8 — N/A (existing firmware behavior, not new in AMRSW-2903)
- [ ] V9 — N/A (requires active task + Fleet API cancel; RESUME_WAIT → NORMAL verified by V2)

## Dependent PRs
- https://github.com/LexxPluss/LexxAuto/pull/4252