### PR TITLE
AMRSW-2870 IMU manual calibration for paco

### DIFF
--- a/extra/drivers/sensor/iim42652/iim42652.c
+++ b/extra/drivers/sensor/iim42652/iim42652.c
@@ -211,14 +211,39 @@ static int iim42652_sample_fetch(const struct device *dev,
 	struct iim42652_data *drv_data = dev->data;
 	const struct iim42652_config *cfg = dev->config;
 
+	k_mutex_lock(&drv_data->bus_lock, K_FOREVER);
+
 	/* Read INT_STATUS (0x45) and FIFO_COUNTH(0x46), FIFO_COUNTL(0x47) */
 	result = inv_spi_read(&cfg->spi, REG_INT_STATUS, drv_data->fifo_data, 3);
+	if (result) {
+		LOG_WRN("INT_STATUS/FIFO_COUNT read failed: %d", result);
+		goto out_unlock;
+	}
 
 	if (drv_data->fifo_data[0] & BIT_INT_STATUS_DRDY) {
 		fifo_count = (drv_data->fifo_data[1] << 8)
 			+ (drv_data->fifo_data[2]);
+
+		/* Discard the sample if FIFO_COUNT is zero or runaway — a
+		 * bank-select race or SPI glitch can corrupt the count and
+		 * pushing the decoded packet would emit garbage upstream.
+		 * Clamping was tempting but parsing 2048 bytes of unknown
+		 * content with the same FIFO_HEAD logic is still garbage out. */
+		if (fifo_count == 0 ||
+		    fifo_count > sizeof(drv_data->fifo_data)) {
+			LOG_WRN("fifo_count %u out of range [1, %u], dropping sample",
+				fifo_count,
+				(unsigned int)sizeof(drv_data->fifo_data));
+			result = -EIO;
+			goto out_unlock;
+		}
+
 		result = inv_spi_read(&cfg->spi, REG_FIFO_DATA, drv_data->fifo_data,
 				      fifo_count);
+		if (result) {
+			LOG_WRN("FIFO_DATA read failed: %d", result);
+			goto out_unlock;
+		}
 
 		/* FIFO Data structure
 		 * Packet 1 : FIFO Header(1), AccelX(2), AccelY(2),
@@ -286,7 +311,9 @@ static int iim42652_sample_fetch(const struct device *dev,
 		}
 	}
 
-	return 0;
+out_unlock:
+	k_mutex_unlock(&drv_data->bus_lock);
+	return result;
 }
 
 static int iim42652_attr_set(const struct device *dev,
@@ -420,6 +447,8 @@ static int iim42652_attr_get(const struct device *dev,
 static int iim42652_data_init(struct iim42652_data *data,
 			      const struct iim42652_config *cfg)
 {
+	k_mutex_init(&data->bus_lock);
+
 	data->accel_x = 0;
 	data->accel_y = 0;
 	data->accel_z = 0;

--- a/extra/drivers/sensor/iim42652/iim42652.c
+++ b/extra/drivers/sensor/iim42652/iim42652.c
@@ -24,9 +24,43 @@
 
 LOG_MODULE_REGISTER(IIM42652, CONFIG_SENSOR_LOG_LEVEL);
 
-static const uint16_t iim42652_gyro_sensitivity_x10[] = {
-	1310, 655, 328, 164
+/* Sensitivity tables indexed by FS_SEL register code.
+ * Values come from the IIM-42652 datasheet via the macros in iim42652_reg.h.
+ * Designated initializers ensure the entry order matches the FS_SEL enum
+ * regardless of source order, so adding entries elsewhere stays safe. */
+static const uint8_t iim42652_accel_sensitivity_shift[IIM42652_ACCEL_FS_COUNT] = {
+	[ACCEL_FS_16G] = IIM42652_ACCEL_SENS_16G_SHIFT,
+	[ACCEL_FS_8G]  = IIM42652_ACCEL_SENS_8G_SHIFT,
+	[ACCEL_FS_4G]  = IIM42652_ACCEL_SENS_4G_SHIFT,
+	[ACCEL_FS_2G]  = IIM42652_ACCEL_SENS_2G_SHIFT,
 };
+
+static const uint16_t iim42652_gyro_sensitivity_x10[IIM42652_GYRO_FS_COUNT] = {
+	[GYRO_FS_2000DPS] = IIM42652_GYRO_SENS_2000DPS_X10,
+	[GYRO_FS_1000DPS] = IIM42652_GYRO_SENS_1000DPS_X10,
+	[GYRO_FS_500DPS]  = IIM42652_GYRO_SENS_500DPS_X10,
+	[GYRO_FS_250DPS]  = IIM42652_GYRO_SENS_250DPS_X10,
+	[GYRO_FS_125DPS]  = IIM42652_GYRO_SENS_125DPS_X10,
+	[GYRO_FS_62DPS]   = IIM42652_GYRO_SENS_62DPS_X10,
+	[GYRO_FS_32DPS]   = IIM42652_GYRO_SENS_32DPS_X10,
+	[GYRO_FS_15DPS]   = IIM42652_GYRO_SENS_15DPS_X10,
+};
+
+/* Callers (iim42652_set_fs, iim42652_attr_set, devicetree-backed init) are
+ * responsible for range-checking sf_idx before reaching here, so the cached
+ * SI conversion factor always stays in sync with what gets written to the
+ * FS register. The assert catches programming mistakes during development. */
+static void update_accel_sensitivity(struct iim42652_data *data, uint8_t sf_idx)
+{
+	__ASSERT_NO_MSG(sf_idx < IIM42652_ACCEL_FS_COUNT);
+	data->accel_sensitivity_shift = iim42652_accel_sensitivity_shift[sf_idx];
+}
+
+static void update_gyro_sensitivity(struct iim42652_data *data, uint8_t sf_idx)
+{
+	__ASSERT_NO_MSG(sf_idx < IIM42652_GYRO_FS_COUNT);
+	data->gyro_sensitivity_x10 = iim42652_gyro_sensitivity_x10[sf_idx];
+}
 
 /* see "Accelerometer Measurements" section from register map description */
 static void iim42652_convert_accel(struct sensor_value *val,
@@ -264,6 +298,16 @@ static int iim42652_attr_set(const struct device *dev,
 
 	__ASSERT_NO_MSG(val != NULL);
 
+	/* ODR and FS are written to the chip only during turn_on_sensor().
+	 * Reject runtime changes; caller must turn_off_sensor() first so
+	 * the cached config matches what was last written to hardware. */
+	if ((attr == SENSOR_ATTR_SAMPLING_FREQUENCY ||
+	     attr == SENSOR_ATTR_FULL_SCALE) &&
+	    drv_data->sensor_started) {
+		LOG_WRN("Config change requires turn_off_sensor first");
+		return -EBUSY;
+	}
+
 	switch (chan) {
 	case SENSOR_CHAN_ACCEL_X:
 	case SENSOR_CHAN_ACCEL_Y:
@@ -283,6 +327,8 @@ static int iim42652_attr_set(const struct device *dev,
 				return -EINVAL;
 			} else {
 				drv_data->accel_sf = val->val1;
+				update_accel_sensitivity(drv_data,
+							 drv_data->accel_sf);
 			}
 		} else {
 			LOG_ERR("Not supported ATTR");
@@ -308,6 +354,8 @@ static int iim42652_attr_set(const struct device *dev,
 				return -EINVAL;
 			} else {
 				drv_data->gyro_sf = val->val1;
+				update_gyro_sensitivity(drv_data,
+							drv_data->gyro_sf);
 			}
 		} else {
 			LOG_ERR("Not supported ATTR");
@@ -405,8 +453,8 @@ static int iim42652_init(const struct device *dev)
 	iim42652_data_init(drv_data, cfg);
 	iim42652_sensor_init(dev);
 
-	drv_data->accel_sensitivity_shift = 14 - 3;
-	drv_data->gyro_sensitivity_x10 = iim42652_gyro_sensitivity_x10[3];
+	update_accel_sensitivity(drv_data, drv_data->accel_sf);
+	update_gyro_sensitivity(drv_data, drv_data->gyro_sf);
 
 #ifdef CONFIG_IIM42652_TRIGGER
 	if (iim42652_init_interrupt(dev) < 0) {

--- a/extra/drivers/sensor/iim42652/iim42652.h
+++ b/extra/drivers/sensor/iim42652/iim42652.h
@@ -25,6 +25,14 @@ typedef void (*tap_fetch_t)(const struct device *dev);
 int iim42652_tap_fetch(const struct device *dev);
 
 struct iim42652_data {
+	/* Serializes SPI bus access and (more importantly) bank-select
+	 * transitions across sample_fetch() and any diagnostic / runtime path
+	 * that selects a non-zero bank. Without this, a 50 Hz sample_fetch()
+	 * running concurrently with a Bank-4 access can read INT_STATUS /
+	 * FIFO_COUNT / FIFO_DATA from the wrong bank and end up with bogus
+	 * fifo_count, which previously could overrun fifo_data[]. */
+	struct k_mutex bus_lock;
+
 	uint8_t fifo_data[HARDWARE_FIFO_SIZE];
 
 	int16_t accel_x;

--- a/extra/drivers/sensor/iim42652/iim42652_reg.h
+++ b/extra/drivers/sensor/iim42652/iim42652_reg.h
@@ -547,4 +547,27 @@ enum {
 	ACCEL_FS_2G,
 };
 
+/* Number of valid FS_SEL codes (matches the enums above). */
+#define IIM42652_ACCEL_FS_COUNT		4
+#define IIM42652_GYRO_FS_COUNT		8
+
+/* Datasheet sensitivities per IIM-42652 register map (Sections 3.1, 3.2).
+ * Accel sensitivity (LSB/g) is a power of 2, expressed as a right-shift
+ * applied to (raw * SENSOR_G) in iim42652_convert_accel(). */
+#define IIM42652_ACCEL_SENS_16G_SHIFT	11	/* 2048 LSB/g = 2^11 */
+#define IIM42652_ACCEL_SENS_8G_SHIFT	12	/* 4096 LSB/g = 2^12 */
+#define IIM42652_ACCEL_SENS_4G_SHIFT	13	/* 8192 LSB/g = 2^13 */
+#define IIM42652_ACCEL_SENS_2G_SHIFT	14	/* 16384 LSB/g = 2^14 */
+
+/* Gyro sensitivity stored x10 to preserve fractional LSB/(deg/s) values
+ * in integer arithmetic (see iim42652_convert_gyro()). */
+#define IIM42652_GYRO_SENS_2000DPS_X10	164	/* 16.4 LSB/(deg/s) */
+#define IIM42652_GYRO_SENS_1000DPS_X10	328	/* 32.8 LSB/(deg/s) */
+#define IIM42652_GYRO_SENS_500DPS_X10	655	/* 65.5 LSB/(deg/s) */
+#define IIM42652_GYRO_SENS_250DPS_X10	1310	/* 131.0 LSB/(deg/s) */
+#define IIM42652_GYRO_SENS_125DPS_X10	2620	/* 262.0 LSB/(deg/s) */
+#define IIM42652_GYRO_SENS_62DPS_X10	5243	/* 524.3 LSB/(deg/s) */
+#define IIM42652_GYRO_SENS_32DPS_X10	10486	/* 1048.6 LSB/(deg/s) */
+#define IIM42652_GYRO_SENS_15DPS_X10	20972	/* 2097.2 LSB/(deg/s) */
+
 #endif /* __SENSOR_IIM42652_IIM42652_REG__ */

--- a/extra/drivers/sensor/iim42652/iim42652_setup.c
+++ b/extra/drivers/sensor/iim42652/iim42652_setup.c
@@ -197,7 +197,21 @@ int iim42652_sensor_init(const struct device *dev)
 	/* Need at least 10ms after soft reset */
 	k_msleep(10);
 
-	v = BIT_GYRO_AFSR_MODE_HFS | BIT_ACCEL_AFSR_MODE_HFS | BIT_CLK_SEL_PLL;
+	/* INTF_CONFIG1 RMW: preserve reserved bits[7:4] (DS §14.29). The previous
+	 * unconditional write of (BIT_GYRO_AFSR_MODE_HFS | BIT_ACCEL_AFSR_MODE_HFS |
+	 * BIT_CLK_SEL_PLL) = 0x51 clobbered reserved bits 7 and 4. The AFSR_MODE
+	 * macros were carried over from ICM-426xx and are not applicable to
+	 * IIM-42652 — writing them is undefined behavior on this part.
+	 */
+	result = inv_spi_read(&cfg->spi, REG_INTF_CONFIG1, &v, 1);
+	if (result) {
+		LOG_ERR("read REG_INTF_CONFIG1 failed");
+		return result;
+	}
+	LOG_INF("INTF_CONFIG1 reset value = 0x%02X", v);
+
+	v &= ~0x0F;             /* clear ACCEL_LP_CLK_SEL, RTC_MODE, CLKSEL */
+	v |= BIT_CLK_SEL_PLL;   /* set CLKSEL = PLL */
 
 	result = inv_spi_single_write(&cfg->spi, REG_INTF_CONFIG1, &v);
 
@@ -205,6 +219,7 @@ int iim42652_sensor_init(const struct device *dev)
 		LOG_ERR("write REG_INTF_CONFIG1 failed");
 		return result;
 	}
+	LOG_INF("INTF_CONFIG1 after RMW   = 0x%02X", v);
 
 	v = BIT_EN_DREG_FIFO_D2A |
 	    BIT_TMST_TO_REGS_EN |
@@ -476,4 +491,213 @@ int iim42652_turn_off_sensor(const struct device *dev)
 	iim42652_turn_off_fifo(dev);
 
 	return 0;
+}
+
+/* Write all six OFFSET_USER channels in one operation (DS §18).
+ *
+ *   gyro  step unit  = 1/32 dps      (range ±64 dps,    12-bit signed)
+ *   accel step unit  = 0.5 mG        (range ±1 g,        12-bit signed)
+ *
+ * Per DS §12.9 the register must be written with accel + gyro powered down.
+ * We only touch PWR_MGMT0 (not FIFO), so the trigger callback resumes
+ * seamlessly after restore. All 9 OFFSET_USER bytes get rewritten, so the
+ * shared-nibble registers (USER1 / USER4 / USER7) do NOT need RMW — every
+ * bit's source is one of the six caller-supplied step values.
+ *
+ * Sign convention (verified on PACO v71es007):
+ *   sensor_output = sensor_raw + OFFUSER
+ *   - ACCEL_Z: 2026-05-14, plan §3.1 (+40/-56 step experiments)
+ *   - GYRO X/Y/Z: 2026-05-15 (+320 step per axis → ~+320 LSB sensor-frame
+ *     shift on the matching GYRO_DATA register; all three axes same sign
+ *     as accel)
+ * So automated calibration should write OFFUSER = -bias_observed.
+ */
+int iim42652_set_offset_user(const struct device *dev,
+			     int16_t gx_step, int16_t gy_step, int16_t gz_step,
+			     int16_t ax_step, int16_t ay_step, int16_t az_step)
+{
+	struct iim42652_data *drv_data = dev->data;
+	const struct iim42652_config *cfg = dev->config;
+	uint8_t saved_pwr, off_val, bank;
+	int rc, rc2;
+	const int16_t steps[6] = {
+		gx_step, gy_step, gz_step,
+		ax_step, ay_step, az_step,
+	};
+	for (int i = 0; i < 6; i++) {
+		if (steps[i] < -2048 || steps[i] > 2047) {
+			return -EINVAL;
+		}
+	}
+
+	/* Build the 9-byte image of OFFSET_USER0..8 from the six 12-bit signed
+	 * fields. Shared-nibble layout from DS §18:
+	 *   USER0 = GX[7:0]
+	 *   USER1 = GY[11:8] | GX[11:8]
+	 *   USER2 = GY[7:0]
+	 *   USER3 = GZ[7:0]
+	 *   USER4 = AX[11:8] | GZ[11:8]
+	 *   USER5 = AX[7:0]
+	 *   USER6 = AY[7:0]
+	 *   USER7 = AZ[11:8] | AY[11:8]
+	 *   USER8 = AZ[7:0]
+	 * Cast through uint16_t before the >>8 to avoid signed-shift ambiguity.
+	 */
+	const uint16_t gx = (uint16_t)gx_step;
+	const uint16_t gy = (uint16_t)gy_step;
+	const uint16_t gz = (uint16_t)gz_step;
+	const uint16_t ax = (uint16_t)ax_step;
+	const uint16_t ay = (uint16_t)ay_step;
+	const uint16_t az = (uint16_t)az_step;
+	uint8_t off[9];
+	off[0] =  gx        & 0xFF;
+	off[1] = ((gy >> 8) & 0x0F) << 4 | ((gx >> 8) & 0x0F);
+	off[2] =  gy        & 0xFF;
+	off[3] =  gz        & 0xFF;
+	off[4] = ((ax >> 8) & 0x0F) << 4 | ((gz >> 8) & 0x0F);
+	off[5] =  ax        & 0xFF;
+	off[6] =  ay        & 0xFF;
+	off[7] = ((az >> 8) & 0x0F) << 4 | ((ay >> 8) & 0x0F);
+	off[8] =  az        & 0xFF;
+
+	k_mutex_lock(&drv_data->bus_lock, K_FOREVER);
+
+	rc = inv_spi_read(&cfg->spi, REG_PWR_MGMT0, &saved_pwr, 1);
+	if (rc) {
+		goto out_unlock;
+	}
+
+	off_val = saved_pwr & ~0x0F;
+	rc = inv_spi_single_write(&cfg->spi, REG_PWR_MGMT0, &off_val);
+	if (rc) {
+		goto restore_pwr;
+	}
+
+	k_msleep(2);
+
+	bank = BIT_BANK_SEL_4;
+	rc = inv_spi_single_write(&cfg->spi, REG_BANK_SEL, &bank);
+	if (rc) {
+		goto restore_bank;
+	}
+
+	for (int i = 0; i < 9; i++) {
+		rc = inv_spi_single_write(&cfg->spi,
+					  REG_OFFSET_USER0 + i,
+					  &off[i]);
+		if (rc) {
+			/* Best-effort recovery: scrub all 9 bytes back to 0 so
+			 * the chip is left in a known (zero-offset) state rather
+			 * than a partial mix of new + old values. We ignore the
+			 * return code of the scrub writes — if the bus is dead
+			 * there's nothing more we can do, but the caller will
+			 * see the original failure code and can decide. */
+			LOG_WRN("OFFSET_USER write failed at byte %d (rc=%d), scrubbing all to 0",
+				i, rc);
+			uint8_t zero = 0;
+			for (int j = 0; j < 9; j++) {
+				(void)inv_spi_single_write(&cfg->spi,
+							   REG_OFFSET_USER0 + j,
+							   &zero);
+			}
+			break;
+		}
+	}
+
+restore_bank:
+	/* Always attempt to restore Bank 0, even if selecting Bank 4 reported
+	 * an error. Everything below this point assumes Bank 0:
+	 *   SIGNAL_PATH_RESET (0x4B) — Bank 4 0x4B is ACCEL_WOM_Y_THR
+	 *   PWR_MGMT0         (0x4E) — Bank 4 0x4E is INT_SOURCE7
+	 * If bank0 select fails we must not write those addresses blindly, or
+	 * we would corrupt the wrong-bank register. Sensors stay powered down. */
+	bank = BIT_BANK_SEL_0;
+	rc2 = inv_spi_single_write(&cfg->spi, REG_BANK_SEL, &bank);
+	const bool bank0_restored_after_off = (rc2 == 0);
+	if (rc == 0) {
+		rc = rc2;
+	}
+
+	if (!bank0_restored_after_off) {
+		LOG_ERR("Bank 0 restore failed (rc=%d); skipping FIFO flush and PWR_MGMT0 restore; sensors left OFF",
+			rc2);
+		goto out_unlock;
+	}
+
+	/* Bank confirmed 0. Flush FIFO best-effort so the first packet after
+	 * we restore PWR_MGMT0 reflects the new OFFSET. */
+	{
+		uint8_t flush = BIT_FIFO_FLUSH;
+		int rc3 = inv_spi_single_write(&cfg->spi,
+					       REG_SIGNAL_PATH_RESET,
+					       &flush);
+		if (rc3) {
+			LOG_WRN("FIFO flush after OFFSET write failed: %d", rc3);
+		}
+	}
+
+restore_pwr:
+	/* Reached either via fall-through from restore_bank (bank0_restored is
+	 * true) or via the early `goto restore_pwr` taken when the PWR_MGMT0
+	 * OFF write itself failed — in that case bank was never switched to
+	 * Bank 4, so PWR_MGMT0 still resolves to the Bank 0 register. */
+	rc2 = inv_spi_single_write(&cfg->spi, REG_PWR_MGMT0, &saved_pwr);
+	if (rc == 0) {
+		rc = rc2;
+	}
+
+	k_msleep(100);
+
+out_unlock:
+	k_mutex_unlock(&drv_data->bus_lock);
+	return rc;
+}
+
+int iim42652_diag_read_regs(const struct device *dev, uint8_t bank, uint8_t addr,
+			    uint8_t *buf, size_t len)
+{
+	struct iim42652_data *drv_data = dev->data;
+	const struct iim42652_config *cfg = dev->config;
+	uint8_t bank_val;
+	int rc;
+
+	if (buf == NULL || len == 0) {
+		return -EINVAL;
+	}
+
+	/* Serialize with sample_fetch() — without this, a 50 Hz fetch could
+	 * land between our bank-select and bank-restore and read INT_STATUS /
+	 * FIFO_COUNT from the wrong bank. */
+	k_mutex_lock(&drv_data->bus_lock, K_FOREVER);
+
+	bank_val = bank;
+	rc = inv_spi_single_write(&cfg->spi, REG_BANK_SEL, &bank_val);
+	if (rc) {
+		/* Bank-select write failed: usually bank is unchanged, but we
+		 * cannot be sure. Fall through to the restore path so Bank 0
+		 * is asserted regardless. */
+		goto restore_bank;
+	}
+
+	rc = inv_spi_read(&cfg->spi, addr, buf, len);
+
+restore_bank:
+	if (bank != BIT_BANK_SEL_0) {
+		uint8_t b0 = BIT_BANK_SEL_0;
+		int rc2 = inv_spi_single_write(&cfg->spi, REG_BANK_SEL, &b0);
+		if (rc == 0) {
+			rc = rc2;
+		}
+		/* If both the original op and the restore failed, the original
+		 * error wins — that's what the caller actually cares about. */
+	}
+
+	k_mutex_unlock(&drv_data->bus_lock);
+	return rc;
+}
+
+int iim42652_diag_read_reg(const struct device *dev, uint8_t bank, uint8_t addr,
+			   uint8_t *val)
+{
+	return iim42652_diag_read_regs(dev, bank, addr, val, 1);
 }

--- a/extra/drivers/sensor/iim42652/iim42652_setup.c
+++ b/extra/drivers/sensor/iim42652/iim42652_setup.c
@@ -26,15 +26,28 @@ int iim42652_set_fs(const struct device *dev, uint16_t a_sf, uint16_t g_sf)
 	uint8_t databuf;
 	int result;
 
+	/* Validate FS_SEL indices against the datasheet code counts
+	 * (4 codes for accel, 8 for gyro; see iim42652_reg.h). */
+	if (a_sf >= IIM42652_ACCEL_FS_COUNT ||
+	    g_sf >= IIM42652_GYRO_FS_COUNT) {
+		LOG_ERR("Invalid FS_SEL a=%u g=%u", a_sf, g_sf);
+		return -EINVAL;
+	}
+	__ASSERT_NO_MSG(a_sf < IIM42652_ACCEL_FS_COUNT &&
+			g_sf < IIM42652_GYRO_FS_COUNT);
+
 	result = inv_spi_read(&cfg->spi, REG_ACCEL_CONFIG0, &databuf, 1);
 	if (result) {
 		return result;
 	}
 	databuf &= ~BIT_ACCEL_FSR;
-
-	databuf |= a_sf;
+	databuf |= ((uint8_t)a_sf << SHIFT_ACCEL_FS_SEL) & BIT_ACCEL_FSR;
 
 	result = inv_spi_single_write(&cfg->spi, REG_ACCEL_CONFIG0, &databuf);
+	if (result) {
+		return result;
+	}
+	LOG_DBG("ACCEL_CONFIG0 written = 0x%02X (FS_SEL=%u)", databuf, a_sf);
 
 	result = inv_spi_read(&cfg->spi, REG_GYRO_CONFIG0, &databuf, 1);
 
@@ -43,13 +56,14 @@ int iim42652_set_fs(const struct device *dev, uint16_t a_sf, uint16_t g_sf)
 	}
 
 	databuf &= ~BIT_GYRO_FSR;
-	databuf |= g_sf;
+	databuf |= ((uint8_t)g_sf << SHIFT_GYRO_FS_SEL) & BIT_GYRO_FSR;
 
 	result = inv_spi_single_write(&cfg->spi, REG_GYRO_CONFIG0, &databuf);
 
 	if (result) {
 		return result;
 	}
+	LOG_DBG("GYRO_CONFIG0 written = 0x%02X (FS_SEL=%u)", databuf, g_sf);
 
 	return 0;
 }

--- a/extra/drivers/sensor/iim42652/iim42652_setup.h
+++ b/extra/drivers/sensor/iim42652/iim42652_setup.h
@@ -12,7 +12,14 @@
 #ifndef ZEPHYR_DRIVERS_SENSOR_IIM42652_IIM42652_SETUP_H_
 #define ZEPHYR_DRIVERS_SENSOR_IIM42652_IIM42652_SETUP_H_
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include <zephyr/device.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 int iim42652_sensor_init(const struct device *dev);
 int iim42652_turn_on_fifo(const struct device *dev);
@@ -20,5 +27,45 @@ int iim42652_turn_off_fifo(const struct device *dev);
 int iim42652_turn_off_sensor(const struct device *dev);
 int iim42652_turn_on_sensor(const struct device *dev);
 int iim42652_set_odr(const struct device *dev, int a_rate, int g_rate);
+
+/* Diagnostic register reads. `bank` is one of BIT_BANK_SEL_{0..4}. Both
+ * variants take the driver's bus mutex, select the requested bank, perform
+ * the read, then restore Bank 0. Sensor power state is not touched — the
+ * caller is responsible for any sensor-off requirements dictated by
+ * DS §12.9 for registers that need it (e.g. AAF, OFFSET_USER).
+ *
+ * The mutex serializes against sample_fetch(); without it a 50 Hz fetch
+ * could land mid-sequence and read the FIFO from the wrong bank.
+ */
+int iim42652_diag_read_reg(const struct device *dev, uint8_t bank, uint8_t addr,
+			   uint8_t *val);
+int iim42652_diag_read_regs(const struct device *dev, uint8_t bank, uint8_t addr,
+			    uint8_t *buf, size_t len);
+
+/* Write all six OFFSET_USER channels (gyro X/Y/Z + accel X/Y/Z) in one
+ * sensor-off cycle. Each step is a 12-bit signed value:
+ *   gyro:  ±2048 step = ±64 dps   (1/32 dps/step ≈ 31.25 mdps/step)
+ *   accel: ±2048 step = ±1 g      (0.5 mG/step)
+ * Returns -EINVAL if any step is outside [-2048, 2047].
+ *
+ * Sign convention (verified on PACO v71es007):
+ *   sensor_output = sensor_raw + OFFUSER
+ *   - ACCEL_Z: 2026-05-14, plan §3.1 (+40/-56 step experiments)
+ *   - GYRO X/Y/Z: 2026-05-15 (+320 step per axis → ~+320 LSB sensor-frame
+ *     shift on the matching GYRO_DATA register; all three axes same sign
+ *     as accel)
+ * So to cancel a measured bias, write step = -bias_observed.
+ *
+ * All 9 OFFSET_USER bytes are rewritten in this call — sibling axes are
+ * NOT preserved. If you only want partial update, read back current
+ * OFFSET_USER0..8 via iim42652_diag_read_regs() first and merge.
+ */
+int iim42652_set_offset_user(const struct device *dev,
+			     int16_t gx_step, int16_t gy_step, int16_t gz_step,
+			     int16_t ax_step, int16_t ay_step, int16_t az_step);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* __SENSOR_IIM42652_IIM42652_SETUP__ */

--- a/lexxpluss_apps/CMakeLists.txt
+++ b/lexxpluss_apps/CMakeLists.txt
@@ -39,6 +39,10 @@ if(USE_TWO_STATE_KEY_SWITCH)
     add_definitions(-DUSE_TWO_STATE_KEY_SWITCH)
 endif()
 
+if(LEXXHARD_IMU_CALIBRATION)
+    add_definitions(-DLEXXHARD_IMU_CALIBRATION)
+endif()
+
 if(VERSION)
     add_definitions(-DVERSION=${VERSION})
 endif()

--- a/lexxpluss_apps/src/imu_calibration.cpp
+++ b/lexxpluss_apps/src/imu_calibration.cpp
@@ -1,0 +1,448 @@
+/*
+ * Copyright (c) 2026, LexxPluss Inc.
+ *
+ * Manual IMU calibration shell - DRY-RUN ONLY (PR #85).
+ *
+ * Behaviour summary (see imu_calibration.hpp for concurrency model):
+ *   `imu calrun`  - one-shot: drain transients, accumulate N_SAMPLES samples
+ *                   off the running IMU fetcher loop, finalize means / stds /
+ *                   would-write OFFSET_USER step values, run envelope + motion
+ *                   gates, print result. Never writes hardware.
+ *   `imu calinfo` - print the last calrun result plus the chip's current
+ *                   OFFSET_USER registers decoded into per-axis step / mG / dps.
+ *
+ * Algorithm is identical to the PACO-verified startup auto-cal v2; only the
+ * trigger has changed (boot path -> manual shell). The actual `OFFSET_USER`
+ * write moves to a follow-up PR (`imu calrun --write`).
+ */
+#include "imu_calibration.hpp"
+
+#ifdef LEXXHARD_IMU_CALIBRATION
+
+#include <algorithm>
+#include <atomic>
+#include <cmath>
+#include <cstdint>
+
+#include <zephyr/kernel.h>
+#include <zephyr/device.h>
+#include <zephyr/devicetree.h>
+#include <zephyr/logging/log.h>
+#include <zephyr/shell/shell.h>
+
+#include "sensor/iim42652/iim42652_reg.h"
+#include "sensor/iim42652/iim42652_setup.h"
+
+LOG_MODULE_DECLARE(imu, CONFIG_SENSOR_LOG_LEVEL);
+
+namespace lexxhard::imu_calibration {
+
+namespace {
+
+/* State machine, with two intermediate states to make all shared-data
+ * writes single-writer:
+ *
+ *   IDLE / DONE / FAILED   - terminal-ish; shell may start a new run
+ *
+ *      shell CAS {IDLE,DONE,FAILED} -> STARTING
+ *      shell exclusively owns g_acc + g_diag (clears both)
+ *      shell release-store STARTING -> RUNNING
+ *
+ *   RUNNING                - fetcher exclusively writes g_acc; nobody
+ *                            writes g_diag
+ *
+ *      whoever CAS-wins RUNNING -> FINALIZING owns g_diag exclusively:
+ *        - fetcher hits N samples in feed_sample() -> finalize()
+ *        - shell timeout in cmd_calrun()
+ *      Winner writes g_diag, then release-store FINALIZING -> DONE/FAILED.
+ *      Loser of the CAS does nothing.
+ *
+ *   FINALIZING             - exclusive g_diag write phase; readers must
+ *                            spin until DONE/FAILED.
+ *
+ * feed_sample() only acts when state == RUNNING. It ignores STARTING and
+ * FINALIZING so the shell side has uncontended access to g_acc / g_diag
+ * during those phases.
+ */
+enum class state_t : int {
+    IDLE = 0,
+    STARTING,
+    RUNNING,
+    FINALIZING,
+    DONE,
+    FAILED,
+};
+
+constexpr int N_SAMPLES = 200;           /* ~4 s @ 50 Hz, same as v2 */
+constexpr int DRAIN_SAMPLES = 5;         /* ~100 ms transient drain */
+constexpr int TIMEOUT_MS = 6000;         /* 4 s nominal + slack */
+constexpr int POLL_INTERVAL_MS = 50;
+
+constexpr double G_LOCAL = 9.80665;
+constexpr double PI_D = 3.14159265358979323846;
+constexpr double RAD_TO_DEG = 180.0 / PI_D;
+constexpr double ACCEL_STEP_MG = 0.5;            /* DS Sec.18, 0.5 mG/step */
+constexpr double GYRO_STEP_MDPS = 1000.0 / 32.0; /* 31.25 mdps/step */
+
+/* Gates - same as PACO-verified v2 (~3-5x static noise floor). */
+constexpr double ENV_AX_AY_MG_LIMIT = 50.0;
+constexpr double ENV_AZ_MG_LIMIT    = 100.0;
+constexpr double ENV_GYRO_DPS_LIMIT = 5.0;
+constexpr double MOTION_ACCEL_STD_MG = 5.0;
+constexpr double MOTION_GYRO_STD_DPS = 0.1;
+
+std::atomic<int> g_state{static_cast<int>(state_t::IDLE)};
+
+struct accumulator_t {
+    int drain_remaining;
+    int collected;
+    double sum_ax, sum_ay, sum_az;
+    double sum_ax2, sum_ay2, sum_az2;
+    double sum_gx, sum_gy, sum_gz;
+    double sum_gx2, sum_gy2, sum_gz2;
+};
+accumulator_t g_acc{};
+
+struct diag_t {
+    bool ever_ran;
+    state_t final_state;
+    int collected;
+    /* sensor frame means + stds */
+    double ax_bias_mg, ay_bias_mg, az_bias_mg;
+    double gx_bias_dps, gy_bias_dps, gz_bias_dps;
+    double az_target_mps2;
+    double ax_std_mg, ay_std_mg, az_std_mg;
+    double gx_std_dps, gy_std_dps, gz_std_dps;
+    /* would-write step values (NOT applied in dry-run) */
+    int16_t ax_step, ay_step, az_step;
+    int16_t gx_step, gy_step, gz_step;
+    /* gate outcomes */
+    bool envelope_ok;
+    bool motion_ok;
+    bool timeout;
+    const char *fail_reason;
+};
+diag_t g_diag{};
+
+double sv_to_d(const struct sensor_value *v) {
+    return static_cast<double>(v->val1) + static_cast<double>(v->val2) * 1e-6;
+}
+
+int16_t clamp_step(double s) {
+    long si = std::lround(s);
+    if (si < -2048) si = -2048;
+    if (si >  2047) si =  2047;
+    return static_cast<int16_t>(si);
+}
+
+void finalize() {
+    /* Claim exclusive g_diag write right via RUNNING -> FINALIZING CAS.
+     * If the shell's timeout path won the race we bail; whatever it wrote
+     * (or zeroed) into g_diag is now authoritative. */
+    int expected = static_cast<int>(state_t::RUNNING);
+    if (!g_state.compare_exchange_strong(
+            expected,
+            static_cast<int>(state_t::FINALIZING),
+            std::memory_order_acq_rel)) {
+        return;
+    }
+
+    constexpr int N = N_SAMPLES;
+    const double ax_mean = g_acc.sum_ax / N;
+    const double ay_mean = g_acc.sum_ay / N;
+    const double az_mean = g_acc.sum_az / N;
+    const double gx_mean = g_acc.sum_gx / N;
+    const double gy_mean = g_acc.sum_gy / N;
+    const double gz_mean = g_acc.sum_gz / N;
+
+    auto var_of = [](double sum2, double mean, int n) {
+        return std::max(0.0, sum2 / n - mean * mean);
+    };
+    const double ax_std = std::sqrt(var_of(g_acc.sum_ax2, ax_mean, N));
+    const double ay_std = std::sqrt(var_of(g_acc.sum_ay2, ay_mean, N));
+    const double az_std = std::sqrt(var_of(g_acc.sum_az2, az_mean, N));
+    const double gx_std = std::sqrt(var_of(g_acc.sum_gx2, gx_mean, N));
+    const double gy_std = std::sqrt(var_of(g_acc.sum_gy2, gy_mean, N));
+    const double gz_std = std::sqrt(var_of(g_acc.sum_gz2, gz_mean, N));
+
+    /* az target sign derived from observed gravity, not hardcoded. */
+    const double az_target = (az_mean >= 0.0) ? +G_LOCAL : -G_LOCAL;
+
+    g_diag.az_target_mps2 = az_target;
+    g_diag.ax_bias_mg  = ax_mean / G_LOCAL * 1000.0;
+    g_diag.ay_bias_mg  = ay_mean / G_LOCAL * 1000.0;
+    g_diag.az_bias_mg  = (az_mean - az_target) / G_LOCAL * 1000.0;
+    g_diag.gx_bias_dps = gx_mean * RAD_TO_DEG;
+    g_diag.gy_bias_dps = gy_mean * RAD_TO_DEG;
+    g_diag.gz_bias_dps = gz_mean * RAD_TO_DEG;
+
+    g_diag.ax_std_mg = ax_std / G_LOCAL * 1000.0;
+    g_diag.ay_std_mg = ay_std / G_LOCAL * 1000.0;
+    g_diag.az_std_mg = az_std / G_LOCAL * 1000.0;
+    g_diag.gx_std_dps = gx_std * RAD_TO_DEG;
+    g_diag.gy_std_dps = gy_std * RAD_TO_DEG;
+    g_diag.gz_std_dps = gz_std * RAD_TO_DEG;
+
+    g_diag.ax_step = clamp_step(-g_diag.ax_bias_mg  / ACCEL_STEP_MG);
+    g_diag.ay_step = clamp_step(-g_diag.ay_bias_mg  / ACCEL_STEP_MG);
+    g_diag.az_step = clamp_step(-g_diag.az_bias_mg  / ACCEL_STEP_MG);
+    g_diag.gx_step = clamp_step(-g_diag.gx_bias_dps * 1000.0 / GYRO_STEP_MDPS);
+    g_diag.gy_step = clamp_step(-g_diag.gy_bias_dps * 1000.0 / GYRO_STEP_MDPS);
+    g_diag.gz_step = clamp_step(-g_diag.gz_bias_dps * 1000.0 / GYRO_STEP_MDPS);
+
+    g_diag.envelope_ok =
+        std::fabs(g_diag.ax_bias_mg)  <= ENV_AX_AY_MG_LIMIT &&
+        std::fabs(g_diag.ay_bias_mg)  <= ENV_AX_AY_MG_LIMIT &&
+        std::fabs(g_diag.az_bias_mg)  <= ENV_AZ_MG_LIMIT    &&
+        std::fabs(g_diag.gx_bias_dps) <= ENV_GYRO_DPS_LIMIT &&
+        std::fabs(g_diag.gy_bias_dps) <= ENV_GYRO_DPS_LIMIT &&
+        std::fabs(g_diag.gz_bias_dps) <= ENV_GYRO_DPS_LIMIT;
+    g_diag.motion_ok =
+        g_diag.ax_std_mg <= MOTION_ACCEL_STD_MG &&
+        g_diag.ay_std_mg <= MOTION_ACCEL_STD_MG &&
+        g_diag.az_std_mg <= MOTION_ACCEL_STD_MG &&
+        g_diag.gx_std_dps <= MOTION_GYRO_STD_DPS &&
+        g_diag.gy_std_dps <= MOTION_GYRO_STD_DPS &&
+        g_diag.gz_std_dps <= MOTION_GYRO_STD_DPS;
+    g_diag.timeout = false;
+    g_diag.collected = g_acc.collected;
+    g_diag.ever_ran = true;
+
+    state_t final_state;
+    if (g_diag.envelope_ok && g_diag.motion_ok) {
+        final_state = state_t::DONE;
+        g_diag.fail_reason = nullptr;
+    } else {
+        final_state = state_t::FAILED;
+        g_diag.fail_reason = !g_diag.envelope_ok ? "envelope (bias too large)"
+                                                 : "motion (std too large)";
+    }
+    g_diag.final_state = final_state;
+
+    /* Release store so shell's acquire load sees a fully written g_diag. */
+    g_state.store(static_cast<int>(final_state), std::memory_order_release);
+}
+
+}  /* anonymous namespace */
+
+void feed_sample(const struct sensor_value accel[3],
+                 const struct sensor_value gyro[3]) {
+    if (g_state.load(std::memory_order_acquire) != static_cast<int>(state_t::RUNNING)) {
+        return;
+    }
+    if (g_acc.drain_remaining > 0) {
+        --g_acc.drain_remaining;
+        return;
+    }
+    if (g_acc.collected >= N_SAMPLES) {
+        return;
+    }
+    const double ax = sv_to_d(&accel[0]);
+    const double ay = sv_to_d(&accel[1]);
+    const double az = sv_to_d(&accel[2]);
+    const double gx = sv_to_d(&gyro[0]);
+    const double gy = sv_to_d(&gyro[1]);
+    const double gz = sv_to_d(&gyro[2]);
+    g_acc.sum_ax += ax; g_acc.sum_ax2 += ax * ax;
+    g_acc.sum_ay += ay; g_acc.sum_ay2 += ay * ay;
+    g_acc.sum_az += az; g_acc.sum_az2 += az * az;
+    g_acc.sum_gx += gx; g_acc.sum_gx2 += gx * gx;
+    g_acc.sum_gy += gy; g_acc.sum_gy2 += gy * gy;
+    g_acc.sum_gz += gz; g_acc.sum_gz2 += gz * gz;
+    if (++g_acc.collected >= N_SAMPLES) {
+        finalize();
+    }
+}
+
+namespace {
+
+void print_diag(const struct shell *shell) {
+    if (!g_diag.ever_ran) {
+        shell_print(shell, "No calibration run yet. Run `imu calrun`.");
+        return;
+    }
+
+    const char *state_name =
+        g_diag.final_state == state_t::DONE   ? "DONE" :
+        g_diag.final_state == state_t::FAILED ? "FAILED" : "?";
+    shell_print(shell, "Last calrun: %s (collected %d / %d)",
+                state_name, g_diag.collected, N_SAMPLES);
+    if (g_diag.final_state != state_t::DONE) {
+        shell_print(shell, "  fail reason: %s",
+                    g_diag.fail_reason ? g_diag.fail_reason : "(none)");
+    }
+
+    shell_print(shell, "[Sensor frame] bias:");
+    shell_print(shell, "  accel mG:  ax=%+.2f ay=%+.2f az=%+.2f (az_target=%+.4f m/s^2)",
+                g_diag.ax_bias_mg, g_diag.ay_bias_mg, g_diag.az_bias_mg,
+                g_diag.az_target_mps2);
+    shell_print(shell, "  gyro  dps: gx=%+.4f gy=%+.4f gz=%+.4f",
+                g_diag.gx_bias_dps, g_diag.gy_bias_dps, g_diag.gz_bias_dps);
+    shell_print(shell, "[Sensor frame] std:");
+    shell_print(shell, "  accel mG:  ax=%.3f ay=%.3f az=%.3f",
+                g_diag.ax_std_mg, g_diag.ay_std_mg, g_diag.az_std_mg);
+    shell_print(shell, "  gyro  dps: gx=%.4f gy=%.4f gz=%.4f",
+                g_diag.gx_std_dps, g_diag.gy_std_dps, g_diag.gz_std_dps);
+
+    /* ROS-frame view: applies the firmware CAN transform (X<->Y swap +
+     * negate-all) AND the SCBDriver receiver's extra accel.y flip, so the
+     * numbers match what `/driver/internal/sensor_set/imu` publishes. */
+    const double ros_ax = -g_diag.ay_bias_mg;
+    const double ros_ay = +g_diag.ax_bias_mg;
+    const double ros_az = -g_diag.az_bias_mg;
+    const double ros_gx = -g_diag.gy_bias_dps;
+    const double ros_gy = -g_diag.gx_bias_dps;
+    const double ros_gz = -g_diag.gz_bias_dps;
+    shell_print(shell, "[ROS frame, /driver/internal/sensor_set/imu] bias:");
+    shell_print(shell, "  accel mG:  x=%+.2f y=%+.2f z=%+.2f", ros_ax, ros_ay, ros_az);
+    shell_print(shell, "  gyro  dps: x=%+.4f y=%+.4f z=%+.4f", ros_gx, ros_gy, ros_gz);
+
+    shell_print(shell, "Would-write OFFSET_USER step (DRY-RUN, NOT applied):");
+    shell_print(shell, "  gyro:  gx=%+5d gy=%+5d gz=%+5d",
+                g_diag.gx_step, g_diag.gy_step, g_diag.gz_step);
+    shell_print(shell,
+                "  accel: ax=%+5d ay=%+5d az=%+5d  (ax/ay would NOT be written "
+                "even with --write; six-face test pending)",
+                g_diag.ax_step, g_diag.ay_step, g_diag.az_step);
+
+    shell_print(shell, "Gates: envelope=%s motion=%s",
+                g_diag.envelope_ok ? "OK" : "FAIL",
+                g_diag.motion_ok   ? "OK" : "FAIL");
+}
+
+void print_current_offset(const struct shell *shell) {
+    const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(imu0));
+    if (!device_is_ready(dev)) {
+        shell_warn(shell, "Cannot read current OFFSET_USER: IMU device not ready");
+        return;
+    }
+    uint8_t buf[9];
+    int rc = iim42652_diag_read_regs(dev, BIT_BANK_SEL_4, REG_OFFSET_USER0, buf, 9);
+    if (rc) {
+        shell_warn(shell, "Read OFFSET_USER0..8 failed rc=%d", rc);
+        return;
+    }
+    auto unpack12 = [](uint8_t lo_byte, uint8_t high_nibble) -> int16_t {
+        uint16_t u = (static_cast<uint16_t>(high_nibble & 0x0F) << 8) | lo_byte;
+        if (u & 0x800) {
+            u |= 0xF000;  /* sign-extend 12-bit -> 16-bit */
+        }
+        return static_cast<int16_t>(u);
+    };
+    /* DS Sec.18 OFFSET_USER packing (verified on PACO 2026-05-15 with
+     * az=-56 step -> bytes 00,00,00,00,00,00,00,F0,C8). */
+    const int16_t gx = unpack12(buf[0], (buf[1] >> 4) & 0x0F);
+    const int16_t gy = unpack12(buf[2],  buf[1]       & 0x0F);
+    const int16_t gz = unpack12(buf[3], (buf[4] >> 4) & 0x0F);
+    const int16_t ax = unpack12(buf[5],  buf[4]       & 0x0F);
+    const int16_t ay = unpack12(buf[6], (buf[7] >> 4) & 0x0F);
+    const int16_t az = unpack12(buf[8],  buf[7]       & 0x0F);
+
+    shell_print(shell, "Current OFFSET_USER (raw bytes 0..8):");
+    shell_print(shell, "  %02X %02X %02X %02X %02X %02X %02X %02X %02X",
+                buf[0], buf[1], buf[2], buf[3], buf[4],
+                buf[5], buf[6], buf[7], buf[8]);
+    shell_print(shell, "Current OFFSET_USER (decoded, sensor frame):");
+    shell_print(shell,
+                "  gyro:  gx=%+5d (%+.3f dps)  gy=%+5d (%+.3f dps)  gz=%+5d (%+.3f dps)",
+                gx, gx * (GYRO_STEP_MDPS / 1000.0),
+                gy, gy * (GYRO_STEP_MDPS / 1000.0),
+                gz, gz * (GYRO_STEP_MDPS / 1000.0));
+    shell_print(shell,
+                "  accel: ax=%+5d (%+.2f mG)  ay=%+5d (%+.2f mG)  az=%+5d (%+.2f mG)",
+                ax, ax * ACCEL_STEP_MG,
+                ay, ay * ACCEL_STEP_MG,
+                az, az * ACCEL_STEP_MG);
+}
+
+}  /* anonymous namespace */
+
+int cmd_calrun(const struct shell *shell, size_t argc, char **argv) {
+    ARG_UNUSED(argc);
+    ARG_UNUSED(argv);
+
+    /* Acquire phase: CAS {IDLE,DONE,FAILED} -> STARTING. While STARTING,
+     * feed_sample() bails out, so we have exclusive access to g_acc and
+     * g_diag and can reset them safely. */
+    auto try_acquire_starting = []() -> bool {
+        for (auto from : {state_t::IDLE, state_t::DONE, state_t::FAILED}) {
+            int expected = static_cast<int>(from);
+            if (g_state.compare_exchange_strong(
+                    expected,
+                    static_cast<int>(state_t::STARTING),
+                    std::memory_order_acq_rel)) {
+                return true;
+            }
+        }
+        return false;
+    };
+    if (!try_acquire_starting()) {
+        shell_error(shell, "Calibration already running. Wait for it to finish.");
+        return 1;
+    }
+
+    /* Single-writer phase: nobody else touches g_acc or g_diag. */
+    g_acc = accumulator_t{};
+    g_acc.drain_remaining = DRAIN_SAMPLES;
+    g_diag = diag_t{};  /* clear stale stats from previous run */
+
+    /* Release-store STARTING -> RUNNING. The fetcher's next acquire-load
+     * sees both the new state AND the cleared accumulator. */
+    g_state.store(static_cast<int>(state_t::RUNNING), std::memory_order_release);
+
+    shell_print(shell,
+                "calrun: dry-run, collecting %d samples (~%d s @ 50 Hz). Keep robot static.",
+                N_SAMPLES, (N_SAMPLES + DRAIN_SAMPLES) / 50);
+
+    const int64_t deadline = k_uptime_get() + TIMEOUT_MS;
+    while (k_uptime_get() < deadline) {
+        int s = g_state.load(std::memory_order_acquire);
+        if (s == static_cast<int>(state_t::DONE) ||
+            s == static_cast<int>(state_t::FAILED)) {
+            break;
+        }
+        k_msleep(POLL_INTERVAL_MS);
+    }
+
+    /* Timeout path. Try to win RUNNING -> FINALIZING; only the winner
+     * gets to write g_diag. If fetcher just finalized concurrently,
+     * we lose the CAS and its g_diag is authoritative. */
+    {
+        int expected = static_cast<int>(state_t::RUNNING);
+        if (g_state.compare_exchange_strong(
+                expected,
+                static_cast<int>(state_t::FINALIZING),
+                std::memory_order_acq_rel)) {
+            g_diag.ever_ran = true;
+            g_diag.timeout = true;
+            g_diag.envelope_ok = false;
+            g_diag.motion_ok = false;
+            g_diag.final_state = state_t::FAILED;
+            g_diag.collected = g_acc.collected;
+            g_diag.fail_reason = "timeout (insufficient samples)";
+            g_state.store(static_cast<int>(state_t::FAILED), std::memory_order_release);
+        } else {
+            /* Fetcher won the race. Wait briefly for it to publish DONE/FAILED. */
+            while (g_state.load(std::memory_order_acquire) ==
+                   static_cast<int>(state_t::FINALIZING)) {
+                k_yield();
+            }
+        }
+    }
+
+    print_diag(shell);
+    return g_diag.final_state == state_t::DONE ? 0 : 1;
+}
+
+int cmd_calinfo(const struct shell *shell, size_t argc, char **argv) {
+    ARG_UNUSED(argc);
+    ARG_UNUSED(argv);
+    print_diag(shell);
+    shell_print(shell, "");
+    print_current_offset(shell);
+    return 0;
+}
+
+}  /* namespace lexxhard::imu_calibration */
+
+#endif  /* LEXXHARD_IMU_CALIBRATION */

--- a/lexxpluss_apps/src/imu_calibration.cpp
+++ b/lexxpluss_apps/src/imu_calibration.cpp
@@ -1,19 +1,35 @@
 /*
  * Copyright (c) 2026, LexxPluss Inc.
  *
- * Manual IMU calibration shell - DRY-RUN ONLY (PR #85).
+ * Manual IMU calibration shell (PR #86).
  *
  * Behaviour summary (see imu_calibration.hpp for concurrency model):
- *   `imu calrun`  - one-shot: drain transients, accumulate N_SAMPLES samples
- *                   off the running IMU fetcher loop, finalize means / stds /
- *                   would-write OFFSET_USER step values, run envelope + motion
- *                   gates, print result. Never writes hardware.
- *   `imu calinfo` - print the last calrun result plus the chip's current
- *                   OFFSET_USER registers decoded into per-axis step / mG / dps.
+ *   `imu calrun`         - dry-run: drain transients, accumulate N_SAMPLES
+ *                          samples off the running IMU fetcher loop, finalize
+ *                          means / stds / would-write OFFSET_USER step values,
+ *                          run envelope + motion gates, print result. Never
+ *                          writes hardware.
+ *   `imu calrun --write` - same collection, then (only if both gates pass)
+ *                          writes GYRO_X/Y/Z + ACCEL_Z OFFSET_USER. ACCEL_X/Y
+ *                          are read-merged (current register values preserved,
+ *                          NOT overwritten and NOT forced to 0) because a
+ *                          single static pose cannot separate sensor zero-g
+ *                          offset from mounting tilt — six-face test pending.
+ *   `imu calinfo`        - print the last calrun result plus the chip's current
+ *                          OFFSET_USER registers decoded into step / mG / dps.
  *
- * Algorithm is identical to the PACO-verified startup auto-cal v2; only the
- * trigger has changed (boot path -> manual shell). The actual `OFFSET_USER`
- * write moves to a follow-up PR (`imu calrun --write`).
+ * Collection algorithm is identical to the PACO-verified startup auto-cal v2;
+ * only the trigger changed (boot path -> manual shell). The write path reuses
+ * the driver's iim42652_set_offset_user(), verified on PACO 2026-05-15.
+ *
+ * Safety invariants for --write:
+ *   - default (no arg) never writes;
+ *   - only `imu calrun --write` (exactly) requests a write; any other arg is
+ *     rejected before sampling starts;
+ *   - write happens only when final_state == DONE (envelope + motion gates
+ *     both pass); gate fail / timeout => no write;
+ *   - if reading the current OFFSET_USER (for ACCEL_X/Y merge) fails, --write
+ *     aborts without writing — it never degrades to ax/ay = 0.
  */
 #include "imu_calibration.hpp"
 
@@ -23,6 +39,7 @@
 #include <atomic>
 #include <cmath>
 #include <cstdint>
+#include <cstring>
 
 #include <zephyr/kernel.h>
 #include <zephyr/device.h>
@@ -100,6 +117,8 @@ struct accumulator_t {
     double sum_ax2, sum_ay2, sum_az2;
     double sum_gx, sum_gy, sum_gz;
     double sum_gx2, sum_gy2, sum_gz2;
+    int64_t t_run_start_ms;    /* shell sets at RUNNING store */
+    int64_t t_first_sample_ms; /* fetcher sets on first post-drain sample */
 };
 accumulator_t g_acc{};
 
@@ -121,11 +140,48 @@ struct diag_t {
     bool motion_ok;
     bool timeout;
     const char *fail_reason;
+    /* timing (ms); -1 = not measured for this run */
+    int64_t t_collect_done_ms; /* finalize() timestamp, for shell poll_lag calc */
+    int drain_ms;
+    int sample_ms;
+    int collect_total_ms;
 };
 diag_t g_diag{};
 
 double sv_to_d(const struct sensor_value *v) {
     return static_cast<double>(v->val1) + static_cast<double>(v->val2) * 1e-6;
+}
+
+/* DS Sec.18 OFFSET_USER 12-bit signed unpack (shared by readback + ax/ay merge). */
+int16_t unpack12(uint8_t lo_byte, uint8_t high_nibble) {
+    uint16_t u = (static_cast<uint16_t>(high_nibble & 0x0F) << 8) | lo_byte;
+    if (u & 0x800) {
+        u |= 0xF000;  /* sign-extend 12-bit -> 16-bit */
+    }
+    return static_cast<int16_t>(u);
+}
+
+struct offset_steps_t {
+    int16_t gx, gy, gz, ax, ay, az;
+};
+
+/* Decode the 9-byte OFFSET_USER0..8 image into six 12-bit signed steps.
+ * MUST mirror iim42652_set_offset_user()'s packing exactly (the encoder is
+ * the single source of truth):
+ *   USER1 = GY[11:8]<<4 | GX[11:8]   (high nibble = GY, low nibble = GX)
+ *   USER4 = AX[11:8]<<4 | GZ[11:8]   (high nibble = AX, low nibble = GZ)
+ *   USER7 = AZ[11:8]<<4 | AY[11:8]   (high nibble = AZ, low nibble = AY)
+ * Cross-check: PACO 2026-05-15 az=-56 step (0xFC8) -> bytes ...,F0,C8, i.e.
+ * AZ[11:8]=0xF lives in USER7's HIGH nibble -> az = unpack12(buf[8], buf[7]>>4). */
+offset_steps_t decode_offset_user(const uint8_t buf[9]) {
+    return offset_steps_t{
+        /* gx */ unpack12(buf[0],  buf[1]       & 0x0F),
+        /* gy */ unpack12(buf[2], (buf[1] >> 4) & 0x0F),
+        /* gz */ unpack12(buf[3],  buf[4]       & 0x0F),
+        /* ax */ unpack12(buf[5], (buf[4] >> 4) & 0x0F),
+        /* ay */ unpack12(buf[6],  buf[7]       & 0x0F),
+        /* az */ unpack12(buf[8], (buf[7] >> 4) & 0x0F),
+    };
 }
 
 int16_t clamp_step(double s) {
@@ -146,6 +202,8 @@ void finalize() {
             std::memory_order_acq_rel)) {
         return;
     }
+
+    const int64_t t_collect_done = k_uptime_get();
 
     constexpr int N = N_SAMPLES;
     const double ax_mean = g_acc.sum_ax / N;
@@ -208,6 +266,11 @@ void finalize() {
     g_diag.collected = g_acc.collected;
     g_diag.ever_ran = true;
 
+    g_diag.t_collect_done_ms = t_collect_done;
+    g_diag.drain_ms = static_cast<int>(g_acc.t_first_sample_ms - g_acc.t_run_start_ms);
+    g_diag.sample_ms = static_cast<int>(t_collect_done - g_acc.t_first_sample_ms);
+    g_diag.collect_total_ms = static_cast<int>(t_collect_done - g_acc.t_run_start_ms);
+
     state_t final_state;
     if (g_diag.envelope_ok && g_diag.motion_ok) {
         final_state = state_t::DONE;
@@ -236,6 +299,9 @@ void feed_sample(const struct sensor_value accel[3],
     }
     if (g_acc.collected >= N_SAMPLES) {
         return;
+    }
+    if (g_acc.collected == 0) {
+        g_acc.t_first_sample_ms = k_uptime_get();  /* first post-drain sample */
     }
     const double ax = sv_to_d(&accel[0]);
     const double ay = sv_to_d(&accel[1]);
@@ -297,11 +363,11 @@ void print_diag(const struct shell *shell) {
     shell_print(shell, "  accel mG:  x=%+.2f y=%+.2f z=%+.2f", ros_ax, ros_ay, ros_az);
     shell_print(shell, "  gyro  dps: x=%+.4f y=%+.4f z=%+.4f", ros_gx, ros_gy, ros_gz);
 
-    shell_print(shell, "Would-write OFFSET_USER step (DRY-RUN, NOT applied):");
+    shell_print(shell, "Correction step (DRY-RUN; --write ADDS this to current OFFSET_USER):");
     shell_print(shell, "  gyro:  gx=%+5d gy=%+5d gz=%+5d",
                 g_diag.gx_step, g_diag.gy_step, g_diag.gz_step);
     shell_print(shell,
-                "  accel: ax=%+5d ay=%+5d az=%+5d  (ax/ay would NOT be written "
+                "  accel: ax=%+5d ay=%+5d az=%+5d  (ax/ay correction NOT applied "
                 "even with --write; six-face test pending)",
                 g_diag.ax_step, g_diag.ay_step, g_diag.az_step);
 
@@ -322,21 +388,7 @@ void print_current_offset(const struct shell *shell) {
         shell_warn(shell, "Read OFFSET_USER0..8 failed rc=%d", rc);
         return;
     }
-    auto unpack12 = [](uint8_t lo_byte, uint8_t high_nibble) -> int16_t {
-        uint16_t u = (static_cast<uint16_t>(high_nibble & 0x0F) << 8) | lo_byte;
-        if (u & 0x800) {
-            u |= 0xF000;  /* sign-extend 12-bit -> 16-bit */
-        }
-        return static_cast<int16_t>(u);
-    };
-    /* DS Sec.18 OFFSET_USER packing (verified on PACO 2026-05-15 with
-     * az=-56 step -> bytes 00,00,00,00,00,00,00,F0,C8). */
-    const int16_t gx = unpack12(buf[0], (buf[1] >> 4) & 0x0F);
-    const int16_t gy = unpack12(buf[2],  buf[1]       & 0x0F);
-    const int16_t gz = unpack12(buf[3], (buf[4] >> 4) & 0x0F);
-    const int16_t ax = unpack12(buf[5],  buf[4]       & 0x0F);
-    const int16_t ay = unpack12(buf[6], (buf[7] >> 4) & 0x0F);
-    const int16_t az = unpack12(buf[8],  buf[7]       & 0x0F);
+    const offset_steps_t o = decode_offset_user(buf);
 
     shell_print(shell, "Current OFFSET_USER (raw bytes 0..8):");
     shell_print(shell, "  %02X %02X %02X %02X %02X %02X %02X %02X %02X",
@@ -345,21 +397,109 @@ void print_current_offset(const struct shell *shell) {
     shell_print(shell, "Current OFFSET_USER (decoded, sensor frame):");
     shell_print(shell,
                 "  gyro:  gx=%+5d (%+.3f dps)  gy=%+5d (%+.3f dps)  gz=%+5d (%+.3f dps)",
-                gx, gx * (GYRO_STEP_MDPS / 1000.0),
-                gy, gy * (GYRO_STEP_MDPS / 1000.0),
-                gz, gz * (GYRO_STEP_MDPS / 1000.0));
+                o.gx, o.gx * (GYRO_STEP_MDPS / 1000.0),
+                o.gy, o.gy * (GYRO_STEP_MDPS / 1000.0),
+                o.gz, o.gz * (GYRO_STEP_MDPS / 1000.0));
     shell_print(shell,
                 "  accel: ax=%+5d (%+.2f mG)  ay=%+5d (%+.2f mG)  az=%+5d (%+.2f mG)",
-                ax, ax * ACCEL_STEP_MG,
-                ay, ay * ACCEL_STEP_MG,
-                az, az * ACCEL_STEP_MG);
+                o.ax, o.ax * ACCEL_STEP_MG,
+                o.ay, o.ay * ACCEL_STEP_MG,
+                o.az, o.az * ACCEL_STEP_MG);
+}
+
+/* Apply the last calrun's correction ON TOP OF the current OFFSET_USER.
+ *
+ * g_diag.*_step is a CORRECTION (= -measured_output_bias), not an absolute
+ * target. Because OFFSET_USER is applied in hardware before the data
+ * registers, calrun always measures the already-compensated output, so the
+ * correction must accumulate:
+ *     final = current + correction        (gx/gy/gz/az)
+ *     final = current                     (ax/ay preserved, correction shown
+ *                                          but not applied; six-face pending)
+ * This makes repeated --write convergent (a second run sees ~0 residual ->
+ * ~0 correction -> stays put) instead of overwriting good compensation.
+ *
+ * Returns 0 on success, negative on failure (nothing written). Aborts before
+ * writing if the current-OFFSET read fails or any final gx/gy/gz/az would
+ * exceed the 12-bit signed range [-2048, 2047] (no silent clamp). write_ms is
+ * the wall time of the set_offset_user() call only. */
+int apply_offset_write(const struct shell *shell, int *write_ms) {
+    *write_ms = -1;
+    const struct device *dev = DEVICE_DT_GET(DT_NODELABEL(imu0));
+    if (!device_is_ready(dev)) {
+        shell_error(shell, "--write aborted: IMU device not ready (nothing written)");
+        return -ENODEV;
+    }
+    /* Read current OFFSET_USER so we can accumulate onto it and preserve
+     * ACCEL_X/Y. If this read fails we abort rather than guess. */
+    uint8_t buf[9];
+    int rc = iim42652_diag_read_regs(dev, BIT_BANK_SEL_4, REG_OFFSET_USER0, buf, 9);
+    if (rc) {
+        shell_error(shell,
+                    "--write aborted: read current OFFSET_USER failed rc=%d "
+                    "(nothing written)", rc);
+        return rc;
+    }
+    const offset_steps_t cur = decode_offset_user(buf);
+
+    /* final = current + correction for gx/gy/gz/az; ax/ay held at current. */
+    const int final_gx = cur.gx + g_diag.gx_step;
+    const int final_gy = cur.gy + g_diag.gy_step;
+    const int final_gz = cur.gz + g_diag.gz_step;
+    const int final_az = cur.az + g_diag.az_step;
+    const int16_t final_ax = cur.ax;
+    const int16_t final_ay = cur.ay;
+
+    /* Range check the accumulated values; abort (no silent clamp) if any
+     * gx/gy/gz/az would saturate the 12-bit signed OFFSET_USER field. */
+    auto out_of_range = [](int v) { return v < -2048 || v > 2047; };
+    if (out_of_range(final_gx) || out_of_range(final_gy) ||
+        out_of_range(final_gz) || out_of_range(final_az)) {
+        shell_error(shell,
+                    "--write aborted: accumulated OFFSET out of [-2048,2047] "
+                    "(final gx=%d gy=%d gz=%d az=%d); nothing written",
+                    final_gx, final_gy, final_gz, final_az);
+        return -ERANGE;
+    }
+
+    shell_print(shell, "OFFSET_USER write:");
+    shell_print(shell, "  current:    gx=%+d gy=%+d gz=%+d ax=%+d ay=%+d az=%+d",
+                cur.gx, cur.gy, cur.gz, cur.ax, cur.ay, cur.az);
+    shell_print(shell,
+                "  correction: gx=%+d gy=%+d gz=%+d ax=%+d ay=%+d az=%+d  "
+                "(ax/ay correction NOT applied; six-face pending)",
+                g_diag.gx_step, g_diag.gy_step, g_diag.gz_step,
+                g_diag.ax_step, g_diag.ay_step, g_diag.az_step);
+    shell_print(shell, "  final:      gx=%+d gy=%+d gz=%+d ax=%+d ay=%+d az=%+d",
+                final_gx, final_gy, final_gz, final_ax, final_ay, final_az);
+
+    const int64_t tw0 = k_uptime_get();
+    rc = iim42652_set_offset_user(dev,
+                                  static_cast<int16_t>(final_gx),
+                                  static_cast<int16_t>(final_gy),
+                                  static_cast<int16_t>(final_gz),
+                                  final_ax, final_ay,
+                                  static_cast<int16_t>(final_az));
+    *write_ms = static_cast<int>(k_uptime_get() - tw0);
+    if (rc) {
+        shell_error(shell, "OFFSET_USER write failed rc=%d", rc);
+        return rc;
+    }
+    return 0;
 }
 
 }  /* anonymous namespace */
 
 int cmd_calrun(const struct shell *shell, size_t argc, char **argv) {
-    ARG_UNUSED(argc);
-    ARG_UNUSED(argv);
+    /* Strict arg parse BEFORE any state change: only `imu calrun` or
+     * `imu calrun --write`. Reject anything else without starting sampling. */
+    bool want_write = false;
+    if (argc == 2 && std::strcmp(argv[1], "--write") == 0) {
+        want_write = true;
+    } else if (argc != 1) {
+        shell_error(shell, "usage: imu calrun [--write]");
+        return -EINVAL;
+    }
 
     /* Acquire phase: CAS {IDLE,DONE,FAILED} -> STARTING. While STARTING,
      * feed_sample() bails out, so we have exclusive access to g_acc and
@@ -384,6 +524,7 @@ int cmd_calrun(const struct shell *shell, size_t argc, char **argv) {
     /* Single-writer phase: nobody else touches g_acc or g_diag. */
     g_acc = accumulator_t{};
     g_acc.drain_remaining = DRAIN_SAMPLES;
+    g_acc.t_run_start_ms = k_uptime_get();
     g_diag = diag_t{};  /* clear stale stats from previous run */
 
     /* Release-store STARTING -> RUNNING. The fetcher's next acquire-load
@@ -391,7 +532,8 @@ int cmd_calrun(const struct shell *shell, size_t argc, char **argv) {
     g_state.store(static_cast<int>(state_t::RUNNING), std::memory_order_release);
 
     shell_print(shell,
-                "calrun: dry-run, collecting %d samples (~%d s @ 50 Hz). Keep robot static.",
+                "calrun: %s, collecting %d samples (~%d s @ 50 Hz). Keep robot static.",
+                want_write ? "WILL WRITE on gate pass" : "dry-run",
                 N_SAMPLES, (N_SAMPLES + DRAIN_SAMPLES) / 50);
 
     const int64_t deadline = k_uptime_get() + TIMEOUT_MS;
@@ -430,8 +572,54 @@ int cmd_calrun(const struct shell *shell, size_t argc, char **argv) {
         }
     }
 
+    const int64_t t_observed = k_uptime_get();
     print_diag(shell);
-    return g_diag.final_state == state_t::DONE ? 0 : 1;
+
+    /* --write: only on a clean DONE (both gates passed). gate fail / timeout
+     * => skip, never write. */
+    int write_ms = -1;
+    int write_rc = 0;
+    if (want_write) {
+        if (g_diag.final_state == state_t::DONE) {
+            write_rc = apply_offset_write(shell, &write_ms);
+            shell_print(shell, "");
+            print_current_offset(shell);
+        } else {
+            shell_print(shell, "--write skipped: gates did not pass (nothing written)");
+        }
+    }
+
+    /* Timing block. poll_lag = shell wakeup latency after finalize; kept
+     * separate from print time. total spans run-start to end of write/print. */
+    const int64_t t_end = k_uptime_get();
+    if (g_diag.timeout) {
+        shell_print(shell, "calrun timing: timed out after %d ms (no valid collection)",
+                    static_cast<int>(t_end - g_acc.t_run_start_ms));
+    } else {
+        const int poll_lag_ms = static_cast<int>(t_observed - g_diag.t_collect_done_ms);
+        const int total_ms = static_cast<int>(t_end - g_acc.t_run_start_ms);
+        if (write_ms >= 0) {
+            shell_print(shell,
+                        "calrun timing: drain_ms=%d sample_ms=%d collect_total_ms=%d "
+                        "poll_lag_ms=%d write_ms=%d total_ms=%d",
+                        g_diag.drain_ms, g_diag.sample_ms, g_diag.collect_total_ms,
+                        poll_lag_ms, write_ms, total_ms);
+        } else {
+            shell_print(shell,
+                        "calrun timing: drain_ms=%d sample_ms=%d collect_total_ms=%d "
+                        "poll_lag_ms=%d write_ms=n/a total_ms=%d",
+                        g_diag.drain_ms, g_diag.sample_ms, g_diag.collect_total_ms,
+                        poll_lag_ms, total_ms);
+        }
+    }
+
+    /* Calibration gate failure (or timeout) => non-zero. A clean cal that then
+     * failed to write (--write) must also surface as non-zero so the shell
+     * layer does not treat "collected OK but write failed" as success. */
+    if (g_diag.final_state != state_t::DONE) {
+        return 1;
+    }
+    return write_rc;  /* 0 on dry-run / successful write, non-zero on write failure */
 }
 
 int cmd_calinfo(const struct shell *shell, size_t argc, char **argv) {

--- a/lexxpluss_apps/src/imu_calibration.hpp
+++ b/lexxpluss_apps/src/imu_calibration.hpp
@@ -1,0 +1,53 @@
+/*
+ * Copyright (c) 2026, LexxPluss Inc.
+ *
+ * Manual IMU calibration shell (PR #85, dry-run).
+ *
+ * Gated by LEXXHARD_IMU_CALIBRATION (default OFF). When the flag is off,
+ * feed_sample() collapses to a no-op so the IMU fetcher loop is unchanged.
+ * When on, the shell registers `imu calrun` and `imu calinfo` subcommands.
+ *
+ * Concurrency model (state machine, see imu_calibration.cpp for details):
+ *
+ *   IDLE/DONE/FAILED   shell CAS -> STARTING
+ *   STARTING           shell exclusively writes g_acc + g_diag, then
+ *                      release-store -> RUNNING
+ *   RUNNING            fetcher exclusively writes g_acc via feed_sample()
+ *   FINALIZING         whoever wins RUNNING -> FINALIZING CAS exclusively
+ *                      writes g_diag (fetcher in finalize(), or shell on
+ *                      timeout). Loser does nothing.
+ *   DONE/FAILED        terminal; g_diag is stable and safe to read after
+ *                      an acquire-load observes one of these.
+ *
+ * feed_sample() only acts when state == RUNNING; STARTING and FINALIZING
+ * make it bail, so the shell side has uncontended access to shared data
+ * during those phases.
+ */
+#pragma once
+
+#include <zephyr/drivers/sensor.h>
+
+#ifdef LEXXHARD_IMU_CALIBRATION
+
+#include <zephyr/shell/shell.h>
+
+namespace lexxhard::imu_calibration {
+
+void feed_sample(const struct sensor_value accel[3],
+                 const struct sensor_value gyro[3]);
+
+int cmd_calrun(const struct shell *shell, size_t argc, char **argv);
+int cmd_calinfo(const struct shell *shell, size_t argc, char **argv);
+
+}  // namespace lexxhard::imu_calibration
+
+#else  /* LEXXHARD_IMU_CALIBRATION */
+
+namespace lexxhard::imu_calibration {
+
+inline void feed_sample(const struct sensor_value[3],
+                        const struct sensor_value[3]) {}
+
+}  // namespace lexxhard::imu_calibration
+
+#endif  /* LEXXHARD_IMU_CALIBRATION */

--- a/lexxpluss_apps/src/imu_controller.cpp
+++ b/lexxpluss_apps/src/imu_controller.cpp
@@ -24,6 +24,7 @@
  */
 
 #include <algorithm>
+#include <atomic>
 #include <cmath>
 #include <zephyr/kernel.h>
 #include <zephyr/drivers/gpio.h>
@@ -34,6 +35,8 @@
 #include "common.hpp"
 #include "imu_controller.hpp"
 #include "runaway_detector.hpp"
+#include "sensor/iim42652/iim42652_reg.h"
+#include "sensor/iim42652/iim42652_setup.h"
 
 namespace lexxhard::imu_controller {
 
@@ -41,7 +44,7 @@ LOG_MODULE_REGISTER(imu);
 
 char __aligned(4) msgq_buffer[8 * sizeof (msg)];
 static struct sensor_trigger data_trigger;
-bool int_flag{false};
+std::atomic<bool> int_flag{false};
 
 class imu_fetcher {
 public:
@@ -161,6 +164,113 @@ public:
             k_msleep(1);
         }
     }
+    void regdump(const struct shell *shell) const {
+        if (!device_is_ready(dev)) {
+            shell_error(shell, "IMU device not ready");
+            return;
+        }
+
+        struct entry {
+            const char *name;
+            uint8_t bank;
+            uint8_t addr;
+        };
+        static const entry table[] = {
+            {"WHO_AM_I            (B0 0x75)", BIT_BANK_SEL_0, REG_WHO_AM_I},
+            {"DEVICE_CONFIG       (B0 0x11)", BIT_BANK_SEL_0, REG_DEVICE_CONFIG},
+            {"INTF_CONFIG0        (B0 0x4C)", BIT_BANK_SEL_0, REG_INTF_CONFIG0},
+            {"INTF_CONFIG1        (B0 0x4D)", BIT_BANK_SEL_0, REG_INTF_CONFIG1},
+            {"PWR_MGMT0           (B0 0x4E)", BIT_BANK_SEL_0, REG_PWR_MGMT0},
+            {"GYRO_CONFIG0        (B0 0x4F)", BIT_BANK_SEL_0, REG_GYRO_CONFIG0},
+            {"ACCEL_CONFIG0       (B0 0x50)", BIT_BANK_SEL_0, REG_ACCEL_CONFIG0},
+            {"GYRO_CONFIG1        (B0 0x51)", BIT_BANK_SEL_0, REG_GYRO_CONFIG1},
+            {"GYRO_ACCEL_CONFIG0  (B0 0x52)", BIT_BANK_SEL_0, REG_GYRO_ACCEL_CONFIG0},
+            {"ACCEL_CONFIG1       (B0 0x53)", BIT_BANK_SEL_0, REG_ACCEL_CONFIG1},
+            {"SELF_TEST_CONFIG    (B0 0x70)", BIT_BANK_SEL_0, REG_SELF_TEST_CONFIG},
+            {"TEMP_DATA1          (B0 0x1D)", BIT_BANK_SEL_0, REG_TEMP_DATA1},
+            {"TEMP_DATA0          (B0 0x1E)", BIT_BANK_SEL_0, REG_TEMP_DATA0},
+            {"ACCEL_DATA_X1       (B0 0x1F)", BIT_BANK_SEL_0, REG_ACCEL_DATA_X1},
+            {"ACCEL_DATA_X0       (B0 0x20)", BIT_BANK_SEL_0, REG_ACCEL_DATA_X0},
+            {"ACCEL_DATA_Y1       (B0 0x21)", BIT_BANK_SEL_0, REG_ACCEL_DATA_Y1},
+            {"ACCEL_DATA_Y0       (B0 0x22)", BIT_BANK_SEL_0, REG_ACCEL_DATA_Y0},
+            {"ACCEL_DATA_Z1       (B0 0x23)", BIT_BANK_SEL_0, REG_ACCEL_DATA_Z1},
+            {"ACCEL_DATA_Z0       (B0 0x24)", BIT_BANK_SEL_0, REG_ACCEL_DATA_Z0},
+            {"GYRO_DATA_X1        (B0 0x25)", BIT_BANK_SEL_0, REG_GYRO_DATA_X1},
+            {"GYRO_DATA_X0        (B0 0x26)", BIT_BANK_SEL_0, REG_GYRO_DATA_X0},
+            {"GYRO_DATA_Y1        (B0 0x27)", BIT_BANK_SEL_0, REG_GYRO_DATA_Y1},
+            {"GYRO_DATA_Y0        (B0 0x28)", BIT_BANK_SEL_0, REG_GYRO_DATA_Y0},
+            {"GYRO_DATA_Z1        (B0 0x29)", BIT_BANK_SEL_0, REG_GYRO_DATA_Z1},
+            {"GYRO_DATA_Z0        (B0 0x2A)", BIT_BANK_SEL_0, REG_GYRO_DATA_Z0},
+            {"OFFSET_USER0        (B4 0x77)", BIT_BANK_SEL_4, REG_OFFSET_USER0},
+            {"OFFSET_USER1        (B4 0x78)", BIT_BANK_SEL_4, REG_OFFSET_USER1},
+            {"OFFSET_USER2        (B4 0x79)", BIT_BANK_SEL_4, REG_OFFSET_USER2},
+            {"OFFSET_USER3        (B4 0x7A)", BIT_BANK_SEL_4, REG_OFFSET_USER3},
+            {"OFFSET_USER4        (B4 0x7B)", BIT_BANK_SEL_4, REG_OFFSET_USER4},
+            {"OFFSET_USER5        (B4 0x7C)", BIT_BANK_SEL_4, REG_OFFSET_USER5},
+            {"OFFSET_USER6        (B4 0x7D)", BIT_BANK_SEL_4, REG_OFFSET_USER6},
+            {"OFFSET_USER7        (B4 0x7E)", BIT_BANK_SEL_4, REG_OFFSET_USER7},
+            {"OFFSET_USER8        (B4 0x7F)", BIT_BANK_SEL_4, REG_OFFSET_USER8},
+        };
+
+        shell_print(shell, "IIM-42652 register dump (sensor running, no power-cycle):");
+        uint8_t accel_cfg0 = 0xFF;
+        for (const auto &e : table) {
+            uint8_t v = 0xFF;
+            int rc = iim42652_diag_read_reg(dev, e.bank, e.addr, &v);
+            if (rc == 0) {
+                shell_print(shell, "  %s = 0x%02X", e.name, v);
+            } else {
+                shell_print(shell, "  %s = read err %d", e.name, rc);
+            }
+            if (e.bank == BIT_BANK_SEL_0 && e.addr == REG_ACCEL_CONFIG0 && rc == 0) {
+                accel_cfg0 = v;
+            }
+        }
+
+        /* Atomic 6-byte burst from ACCEL_DATA_X1..Z0 so the three axes come
+         * from the same sample. Iterating single-byte reads in the table
+         * above can split an axis across two ODR ticks at 50 Hz. */
+        uint8_t accel_burst[6] = {0};
+        int rc_burst = iim42652_diag_read_regs(dev, BIT_BANK_SEL_0,
+                                               REG_ACCEL_DATA_X1,
+                                               accel_burst, sizeof(accel_burst));
+        if (rc_burst != 0) {
+            shell_print(shell, "  raw accel burst read err %d", rc_burst);
+            return;
+        }
+
+        int16_t ax = static_cast<int16_t>((accel_burst[0] << 8) | accel_burst[1]);
+        int16_t ay = static_cast<int16_t>((accel_burst[2] << 8) | accel_burst[3]);
+        int16_t az = static_cast<int16_t>((accel_burst[4] << 8) | accel_burst[5]);
+
+        /* Decode FSR from ACCEL_CONFIG0[7:5] (BIT_ACCEL_FSR / SHIFT_ACCEL_FS_SEL).
+         * The shift values come from DS §3.1 and match the driver's
+         * iim42652_accel_sensitivity_shift[] table. */
+        const char *fsr_label = "?";
+        int lsb_shift = -1;
+        if (accel_cfg0 != 0xFF) {
+            uint8_t fs_sel = (accel_cfg0 & BIT_ACCEL_FSR) >> SHIFT_ACCEL_FS_SEL;
+            switch (fs_sel) {
+            case ACCEL_FS_16G: fsr_label = "16g"; lsb_shift = IIM42652_ACCEL_SENS_16G_SHIFT; break;
+            case ACCEL_FS_8G:  fsr_label = "8g";  lsb_shift = IIM42652_ACCEL_SENS_8G_SHIFT; break;
+            case ACCEL_FS_4G:  fsr_label = "4g";  lsb_shift = IIM42652_ACCEL_SENS_4G_SHIFT; break;
+            case ACCEL_FS_2G:  fsr_label = "2g";  lsb_shift = IIM42652_ACCEL_SENS_2G_SHIFT; break;
+            }
+        }
+
+        if (lsb_shift > 0) {
+            float lsb_per_g = static_cast<float>(1u << lsb_shift);
+            shell_print(shell,
+                "  raw accel burst (FSR=%s, %.0f LSB/g): X=%6d (%.4f g)  Y=%6d (%.4f g)  Z=%6d (%.4f g)",
+                fsr_label, lsb_per_g,
+                ax, ax / lsb_per_g, ay, ay / lsb_per_g, az, az / lsb_per_g);
+        } else {
+            shell_print(shell,
+                "  raw accel burst (ACCEL_CONFIG0=0x%02X, FSR unknown): X=%6d Y=%6d Z=%6d",
+                accel_cfg0, ax, ay, az);
+        }
+    }
+
     void info(const shell *shell) const {
         double accel_x = from_fixed<ACCEL_SCALING>(pack_i16t(message.accel_data_upper[0], message.accel_data_lower[0]));
         double accel_y = from_fixed<ACCEL_SCALING>(pack_i16t(message.accel_data_upper[1], message.accel_data_lower[1]));
@@ -233,8 +343,17 @@ int info(const shell *shell, size_t argc, char **argv)
     return 0;
 }
 
+int regdump(const struct shell *shell, size_t argc, char **argv)
+{
+    ARG_UNUSED(argc);
+    ARG_UNUSED(argv);
+    impl.regdump(shell);
+    return 0;
+}
+
 SHELL_STATIC_SUBCMD_SET_CREATE(sub,
     SHELL_CMD(info, NULL, "IMU information", info),
+    SHELL_CMD(regdump, NULL, "IIM-42652 register dump (WHO_AM_I, configs, OFFSET_USER, raw ACCEL/GYRO/TEMP)", regdump),
     SHELL_SUBCMD_SET_END
 );
 SHELL_CMD_REGISTER(imu, &sub, "IMU commands", NULL);

--- a/lexxpluss_apps/src/imu_controller.cpp
+++ b/lexxpluss_apps/src/imu_controller.cpp
@@ -358,7 +358,7 @@ SHELL_STATIC_SUBCMD_SET_CREATE(sub,
     SHELL_CMD(info, NULL, "IMU information", info),
     SHELL_CMD(regdump, NULL, "IIM-42652 register dump (WHO_AM_I, configs, OFFSET_USER, raw ACCEL/GYRO/TEMP)", regdump),
 #ifdef LEXXHARD_IMU_CALIBRATION
-    SHELL_CMD(calrun,  NULL, "Manual calibration dry-run: compute biases + would-write step values; OFFSET_USER NOT touched",
+    SHELL_CMD(calrun,  NULL, "Manual calibration. `calrun` = dry-run (no write). `calrun --write` = write GYRO_X/Y/Z + ACCEL_Z OFFSET_USER on gate pass (ACCEL_X/Y preserved)",
               lexxhard::imu_calibration::cmd_calrun),
     SHELL_CMD(calinfo, NULL, "Show last calrun result + current OFFSET_USER decode",
               lexxhard::imu_calibration::cmd_calinfo),

--- a/lexxpluss_apps/src/imu_controller.cpp
+++ b/lexxpluss_apps/src/imu_controller.cpp
@@ -33,6 +33,7 @@
 #include <zephyr/logging/log.h>
 #include <zephyr/shell/shell.h>
 #include "common.hpp"
+#include "imu_calibration.hpp"
 #include "imu_controller.hpp"
 #include "runaway_detector.hpp"
 #include "sensor/iim42652/iim42652_reg.h"
@@ -127,6 +128,8 @@ public:
 
                     sensor_channel_get(dev, SENSOR_CHAN_ACCEL_XYZ, accel);
                     sensor_channel_get(dev, SENSOR_CHAN_GYRO_XYZ, gyro);
+
+                    imu_calibration::feed_sample(accel, gyro);
 
                     //sensor -x is system y, sensor -y is systemx, sensor z is system z
                     accel_data[1] = - accel_value_to_int16_t(&accel[0]);
@@ -354,6 +357,12 @@ int regdump(const struct shell *shell, size_t argc, char **argv)
 SHELL_STATIC_SUBCMD_SET_CREATE(sub,
     SHELL_CMD(info, NULL, "IMU information", info),
     SHELL_CMD(regdump, NULL, "IIM-42652 register dump (WHO_AM_I, configs, OFFSET_USER, raw ACCEL/GYRO/TEMP)", regdump),
+#ifdef LEXXHARD_IMU_CALIBRATION
+    SHELL_CMD(calrun,  NULL, "Manual calibration dry-run: compute biases + would-write step values; OFFSET_USER NOT touched",
+              lexxhard::imu_calibration::cmd_calrun),
+    SHELL_CMD(calinfo, NULL, "Show last calrun result + current OFFSET_USER decode",
+              lexxhard::imu_calibration::cmd_calinfo),
+#endif
     SHELL_SUBCMD_SET_END
 );
 SHELL_CMD_REGISTER(imu, &sub, "IMU commands", NULL);


### PR DESCRIPTION
## Summary
- Bring #83/#84/#85/#86 into the paco line on top of #87.
- Fix IIM42652 FS_SEL +/-2g bit shift and sync sensitivity used by OFFSET_USER mG calculations.
- Add IMU driver hardening, OFFSET_USER API, dry-run calibration shell, and calrun --write path behind LEXXHARD_IMU_CALIBRATION.

## Notes
- Default behavior remains off unless firmware is built with -DLEXXHARD_IMU_CALIBRATION=1.
- Branch includes #87 from prod/pj-paco-xxxx-joint-1 via merge commit 12dc462.

## Testing
- Cherry-pick/merge completed cleanly; no conflicts.
- Not run in this step.